### PR TITLE
chore: ignore release.yaml in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:base",
     "github>Turbo87/renovate-config//rust/updateToolchain"
-  ]
+  ],
+  "ignorePaths": [".github/workflows/release.yaml"]
 }


### PR DESCRIPTION
`napi.rs` has crafted a huge 500 lines CI that works perfectly, and has many many workarounds. I already spent a ton configuring it, and it can break very easily with these renovate updates. the CI builds around 14 binaries for various OSs, and to do that, sometimes we HAVE to rely on older dependencies.