### PR TITLE
fix: actix web routing configuration

### DIFF
--- a/bin/conductor/src/lib.rs
+++ b/bin/conductor/src/lib.rs
@@ -53,8 +53,9 @@ pub async fn run_services(config_file_path: &String) -> std::io::Result<()> {
         for conductor_route in gateway.routes.iter() {
           let child_router = Scope::new(conductor_route.base_path.as_str())
             .app_data(web::Data::new(conductor_route.route_data.clone()))
-            .route("{tail:.*}", web::route().to(handler))
-            .route("", web::route().to(handler));
+            .service(Scope::new("").default_service(
+              web::route().to(handler), // handle all requests with this handler
+            ));
 
           router = router.service(child_router)
         }


### PR DESCRIPTION
closes #299

the solution uses a few tricks by using `Scope::new()` to define a base path, and within that scope, we attach a `default_service(...)` which is usually used for handling `404`s, but we're effectively using it to catch everything, by defining no routes under that scope.

this setup efficiently captures all requests to the scope, including the root path, directing them to a single handler, so it eliminates the need for separate route definitions for `""` and wildcard paths.