### PR TITLE
feat: schema awareness (+fixed root logger) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,12 +315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,15 +1174,12 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "3.8.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
- "ascii",
- "byteorder",
- "either",
+ "bytes",
  "memchr",
- "unreachable",
 ]
 
 [[package]]
@@ -1261,8 +1252,10 @@ dependencies = [
  "bytes",
  "futures",
  "graphql-parser",
+ "graphql-tools",
  "http 0.2.12",
  "http-body",
+ "lazy_static",
  "mime",
  "minitrace",
  "once_cell",
@@ -1288,6 +1281,8 @@ dependencies = [
  "cors_plugin",
  "disable_introspection_plugin",
  "graphiql_plugin",
+ "graphql_validation_plugin",
+ "http-serde",
  "http_get_plugin",
  "humantime-serde",
  "jwt_auth_plugin",
@@ -1317,6 +1312,7 @@ dependencies = [
  "federation_query_planner",
  "futures",
  "graphiql_plugin",
+ "graphql_validation_plugin",
  "http_get_plugin",
  "humantime",
  "jwt_auth_plugin",
@@ -1689,6 +1685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2175,11 +2172,34 @@ dependencies = [
 [[package]]
 name = "graphql-parser"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
+source = "git+https://github.com/graphql-rust/graphql-parser.git?rev=f75d96f1e026d0fb993944793916c1cd0597f44c#f75d96f1e026d0fb993944793916c1cd0597f44c"
 dependencies = [
  "combine",
  "thiserror",
+]
+
+[[package]]
+name = "graphql-tools"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5abc524cafc9e33420583e93b69610e7b92a970d57ae4df55fec0a1932b0b407"
+dependencies = [
+ "graphql-parser",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "graphql_validation_plugin"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "conductor_common",
+ "schemars",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -2328,6 +2348,16 @@ dependencies = [
  "bytes",
  "http 0.2.12",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
+dependencies = [
+ "http 0.2.12",
+ "serde",
 ]
 
 [[package]]
@@ -4390,6 +4420,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5333,15 +5391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5432,12 +5481,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vrl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ reqwest-middleware = "0.2.5"
 tracing-subscriber = "0.3.18"
 base64 = "0.21.7"
 schemars = "0.8.16"
+graphql-parser = { git = "https://github.com/graphql-rust/graphql-parser.git", rev = "f75d96f1e026d0fb993944793916c1cd0597f44c" }
 vrl = { git = "https://github.com/dotansimha/vrl.git", rev = "d59b2f66727d3c345b4202b94265c580dfd0f0e9", default-features = false, features = [
   "string_path",
   "compiler",
@@ -31,3 +32,6 @@ minitrace = "0.6.4"
 [profile.release.package.conductor-cf-worker]
 strip = true
 codegen-units = 1
+
+[patch.crates-io]
+graphql-parser = { git = "https://github.com/graphql-rust/graphql-parser.git", rev = "f75d96f1e026d0fb993944793916c1cd0597f44c" }

--- a/bin/conductor/src/lib.rs
+++ b/bin/conductor/src/lib.rs
@@ -34,7 +34,7 @@ pub async fn run_services(config_file_path: &String) -> std::io::Result<()> {
     Ok(gw) => {
       let subscriber = registry::Registry::default().with(logger);
       // @expected: we need to exit the process, if the logger can't be correctly set.
-      tracing::subscriber::set_global_default(subscriber).expect("failed to set up tracing");
+      let _guard = tracing::subscriber::set_default(subscriber);
       let tracing_reporter = tracing_manager.build_root_reporter();
       minitrace::set_reporter(tracing_reporter, Config::default());
 

--- a/bin/conductor/src/main.rs
+++ b/bin/conductor/src/main.rs
@@ -1,7 +1,20 @@
 use conductor::run_services;
+use conductor_config::LoggerConfig;
+use tracing::subscriber::set_global_default;
+use tracing_subscriber::layer::SubscriberExt;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+  let default_logger_config = LoggerConfig::default();
+  let global_logger = conductor_logger::logger_layer::build_logger(
+    &default_logger_config.format,
+    &default_logger_config.filter,
+    default_logger_config.print_performance_info,
+  )
+  .expect("failed to build logger");
+  set_global_default(tracing_subscriber::registry().with(global_logger))
+    .expect("failed to set global default logger");
+
   let config_file_path = std::env::args()
     .nth(1)
     .unwrap_or("./config.json".to_string());

--- a/libs/benches/bench.rs
+++ b/libs/benches/bench.rs
@@ -81,6 +81,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         id: String::from("s"),
         config: GraphQLSourceConfig {
           endpoint: String::from("http://localhost:4444/graphql"),
+          schema_awareness: None,
         },
       }],
       endpoints: vec![EndpointDefinition {

--- a/libs/common/Cargo.toml
+++ b/libs/common/Cargo.toml
@@ -24,9 +24,11 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
-graphql-parser = "0.4.0"
+graphql-parser = { workspace = true }
+graphql-tools = "0.2.5"
 mime = "0.3.17"
 url = "2.5.0"
 querystring = "1.1.0"
 once_cell = "1.19.0"
 minitrace = { workspace = true }
+lazy_static = "1.4.0"

--- a/libs/common/src/http.rs
+++ b/libs/common/src/http.rs
@@ -20,6 +20,23 @@ pub trait ToHeadersMap {
   fn to_headers_map(&self) -> Result<HttpHeadersMap>;
 }
 
+impl ToHeadersMap for HashMap<String, String> {
+  fn to_headers_map(&self) -> Result<HttpHeadersMap, anyhow::Error> {
+    let mut headers_map = HeaderMap::new();
+
+    for (key, value) in self {
+      let header_name = HeaderName::from_str(key)
+        .map_err(|e| anyhow!("Couldn't parse key into a header name: {}", e))?;
+      let header_value = HeaderValue::from_str(value)
+        .map_err(|e| anyhow!("Couldn't parse value into a header value: {}", e))?;
+
+      headers_map.insert(header_name, header_value);
+    }
+
+    Ok(headers_map)
+  }
+}
+
 impl ToHeadersMap for Vec<(&str, &str)> {
   fn to_headers_map(&self) -> Result<HttpHeadersMap, anyhow::Error> {
     let mut headers_map = HeaderMap::new();

--- a/libs/common/src/introspection.rs
+++ b/libs/common/src/introspection.rs
@@ -1,0 +1,422 @@
+use crate::graphql::ParsedGraphQLSchema;
+use graphql_parser::schema::{
+  Definition, EnumType, EnumValue, Field, InputObjectType, InputValue, InterfaceType, ObjectType,
+  ScalarType, SchemaDefinition, Type, TypeDefinition, UnionType,
+};
+pub use graphql_tools::introspection::IntrospectionQuery as IntrospectionQueryResponse;
+use graphql_tools::introspection::{
+  IntrospectionInputTypeRef, IntrospectionOutputTypeRef, IntrospectionType,
+};
+
+fn serde_value_to_sdl_value(
+  value: serde_json::Value,
+) -> graphql_parser::schema::Value<'static, String> {
+  match value {
+    serde_json::Value::Null => graphql_parser::schema::Value::Null,
+    serde_json::Value::Bool(v) => graphql_parser::schema::Value::Boolean(v),
+    serde_json::Value::Number(v) => {
+      if v.is_i64() {
+        graphql_parser::schema::Value::Int((v.as_i64().unwrap() as i32).into())
+      } else {
+        graphql_parser::schema::Value::Float(v.as_f64().unwrap())
+      }
+    }
+    serde_json::Value::String(v) => graphql_parser::schema::Value::String(v),
+    serde_json::Value::Array(v) => {
+      graphql_parser::schema::Value::List(v.into_iter().map(serde_value_to_sdl_value).collect())
+    }
+    serde_json::Value::Object(v) => graphql_parser::schema::Value::Object(
+      v.into_iter()
+        .map(|(k, v)| (k, serde_value_to_sdl_value(v)))
+        .collect(),
+    ),
+  }
+}
+
+fn introspection_input_typeref_to_sdl_type(
+  type_ref: &IntrospectionInputTypeRef,
+) -> Type<'static, String> {
+  match type_ref {
+    IntrospectionInputTypeRef::SCALAR(s) => Type::NamedType(s.name.clone()),
+    IntrospectionInputTypeRef::ENUM(e) => Type::NamedType(e.name.clone()),
+    IntrospectionInputTypeRef::INPUT_OBJECT(i) => Type::NamedType(i.name.clone()),
+    IntrospectionInputTypeRef::NON_NULL { of_type } => Type::NonNullType(Box::new(
+      introspection_input_typeref_to_sdl_type(of_type.as_ref().unwrap()),
+    )),
+    IntrospectionInputTypeRef::LIST { of_type } => Type::ListType(Box::new(
+      introspection_input_typeref_to_sdl_type(of_type.as_ref().unwrap()),
+    )),
+  }
+}
+
+fn introspection_output_typeref_to_sdl_type(
+  type_ref: &IntrospectionOutputTypeRef,
+) -> Type<'static, String> {
+  match type_ref {
+    IntrospectionOutputTypeRef::INTERFACE(s) => Type::NamedType(s.name.clone()),
+    IntrospectionOutputTypeRef::OBJECT(s) => Type::NamedType(s.name.clone()),
+    IntrospectionOutputTypeRef::UNION(s) => Type::NamedType(s.name.clone()),
+    IntrospectionOutputTypeRef::SCALAR(s) => Type::NamedType(s.name.clone()),
+    IntrospectionOutputTypeRef::ENUM(e) => Type::NamedType(e.name.clone()),
+    IntrospectionOutputTypeRef::INPUT_OBJECT(i) => Type::NamedType(i.name.clone()),
+    IntrospectionOutputTypeRef::NON_NULL { of_type } => Type::NonNullType(Box::new(
+      introspection_output_typeref_to_sdl_type(of_type.as_ref().unwrap()),
+    )),
+    IntrospectionOutputTypeRef::LIST { of_type } => Type::ListType(Box::new(
+      introspection_output_typeref_to_sdl_type(of_type.as_ref().unwrap()),
+    )),
+  }
+}
+
+pub fn introspection_to_sdl(introspection: IntrospectionQueryResponse) -> ParsedGraphQLSchema {
+  let schema_type = introspection.__schema;
+  let schema_definition = Definition::SchemaDefinition(SchemaDefinition {
+    directives: vec![],
+    position: Default::default(),
+    mutation: schema_type.mutation_type.map(|v| v.name),
+    query: Some(schema_type.query_type.name),
+    subscription: schema_type.subscription_type.map(|v| v.name),
+  });
+  let mut result = ParsedGraphQLSchema {
+    definitions: vec![schema_definition],
+  };
+
+  for introspection_directive in schema_type.directives {
+    result.definitions.push(Definition::DirectiveDefinition(
+      graphql_parser::schema::DirectiveDefinition {
+        description: introspection_directive.description,
+        name: introspection_directive.name,
+        position: Default::default(),
+        arguments: introspection_directive
+          .args
+          .into_iter()
+          .map(|introspection_input_value| InputValue {
+            default_value: introspection_input_value
+              .default_value
+              .map(serde_value_to_sdl_value),
+            value_type: introspection_input_typeref_to_sdl_type(
+              &introspection_input_value.type_ref.unwrap(),
+            ),
+            description: introspection_input_value.description,
+            directives: vec![],
+            name: introspection_input_value.name,
+            position: Default::default(),
+          })
+          .collect(),
+        repeatable: introspection_directive.is_repeatable.is_some_and(|v| v),
+        locations: introspection_directive
+          .locations
+          .into_iter()
+          .map(|v| match v {
+            graphql_tools::introspection::DirectiveLocation::ARGUMENT_DEFINITION => {
+              graphql_parser::schema::DirectiveLocation::ArgumentDefinition
+            }
+            graphql_tools::introspection::DirectiveLocation::VARIABLE_DEFINITION => {
+              graphql_parser::schema::DirectiveLocation::VariableDefinition
+            }
+            graphql_tools::introspection::DirectiveLocation::ENUM => {
+              graphql_parser::schema::DirectiveLocation::Enum
+            }
+            graphql_tools::introspection::DirectiveLocation::UNION => {
+              graphql_parser::schema::DirectiveLocation::Union
+            }
+            graphql_tools::introspection::DirectiveLocation::ENUM_VALUE => {
+              graphql_parser::schema::DirectiveLocation::EnumValue
+            }
+            graphql_tools::introspection::DirectiveLocation::FIELD => {
+              graphql_parser::schema::DirectiveLocation::Field
+            }
+            graphql_tools::introspection::DirectiveLocation::FIELD_DEFINITION => {
+              graphql_parser::schema::DirectiveLocation::FieldDefinition
+            }
+            graphql_tools::introspection::DirectiveLocation::FRAGMENT_DEFINITION => {
+              graphql_parser::schema::DirectiveLocation::FragmentDefinition
+            }
+            graphql_tools::introspection::DirectiveLocation::FRAGMENT_SPREAD => {
+              graphql_parser::schema::DirectiveLocation::FragmentSpread
+            }
+            graphql_tools::introspection::DirectiveLocation::INLINE_FRAGMENT => {
+              graphql_parser::schema::DirectiveLocation::InlineFragment
+            }
+            graphql_tools::introspection::DirectiveLocation::INPUT_FIELD_DEFINITION => {
+              graphql_parser::schema::DirectiveLocation::InputFieldDefinition
+            }
+            graphql_tools::introspection::DirectiveLocation::INPUT_OBJECT => {
+              graphql_parser::schema::DirectiveLocation::InputObject
+            }
+            graphql_tools::introspection::DirectiveLocation::INTERFACE => {
+              graphql_parser::schema::DirectiveLocation::Interface
+            }
+            graphql_tools::introspection::DirectiveLocation::MUTATION => {
+              graphql_parser::schema::DirectiveLocation::Mutation
+            }
+            graphql_tools::introspection::DirectiveLocation::OBJECT => {
+              graphql_parser::schema::DirectiveLocation::Object
+            }
+            graphql_tools::introspection::DirectiveLocation::QUERY => {
+              graphql_parser::schema::DirectiveLocation::Query
+            }
+            graphql_tools::introspection::DirectiveLocation::SCALAR => {
+              graphql_parser::schema::DirectiveLocation::Scalar
+            }
+            graphql_tools::introspection::DirectiveLocation::SCHEMA => {
+              graphql_parser::schema::DirectiveLocation::Schema
+            }
+            graphql_tools::introspection::DirectiveLocation::SUBSCRIPTION => {
+              graphql_parser::schema::DirectiveLocation::Subscription
+            }
+          })
+          .collect(),
+      },
+    ));
+  }
+
+  for introspection_type in schema_type.types {
+    let schema_type = match introspection_type {
+      IntrospectionType::INTERFACE(introspection_interface) => {
+        TypeDefinition::Interface(InterfaceType {
+          description: introspection_interface.description,
+          directives: vec![],
+          name: introspection_interface.name,
+          position: Default::default(),
+          implements_interfaces: introspection_interface
+            .possible_types
+            .into_iter()
+            .map(|v| v.name)
+            .collect(),
+          fields: introspection_interface
+            .fields
+            .into_iter()
+            .map(|introspection_field| Field {
+              description: introspection_field.description,
+              directives: vec![],
+              name: introspection_field.name,
+              position: Default::default(),
+              arguments: introspection_field
+                .args
+                .into_iter()
+                .map(|introspection_input_value| InputValue {
+                  default_value: introspection_input_value
+                    .default_value
+                    .map(serde_value_to_sdl_value),
+                  value_type: introspection_input_typeref_to_sdl_type(
+                    &introspection_input_value.type_ref.unwrap(),
+                  ),
+                  description: introspection_input_value.description,
+                  directives: vec![],
+                  name: introspection_input_value.name,
+                  position: Default::default(),
+                })
+                .collect(),
+              field_type: introspection_output_typeref_to_sdl_type(&introspection_field.type_ref),
+            })
+            .collect(),
+        })
+      }
+      IntrospectionType::OBJECT(introspection_object_type) => TypeDefinition::Object(ObjectType {
+        description: introspection_object_type.description,
+        directives: vec![],
+        name: introspection_object_type.name,
+        position: Default::default(),
+        implements_interfaces: introspection_object_type
+          .interfaces
+          .into_iter()
+          .map(|v| v.name)
+          .collect(),
+        fields: introspection_object_type
+          .fields
+          .into_iter()
+          .map(|introspection_field| Field {
+            description: introspection_field.description,
+            directives: vec![],
+            name: introspection_field.name,
+            position: Default::default(),
+            arguments: introspection_field
+              .args
+              .into_iter()
+              .map(|introspection_input_value| InputValue {
+                default_value: introspection_input_value
+                  .default_value
+                  .map(serde_value_to_sdl_value),
+                value_type: introspection_input_typeref_to_sdl_type(
+                  &introspection_input_value.type_ref.unwrap(),
+                ),
+                description: introspection_input_value.description,
+                directives: vec![],
+                name: introspection_input_value.name,
+                position: Default::default(),
+              })
+              .collect(),
+            field_type: introspection_output_typeref_to_sdl_type(&introspection_field.type_ref),
+          })
+          .collect(),
+      }),
+      IntrospectionType::INPUT_OBJECT(introspection_input_object) => {
+        TypeDefinition::InputObject(InputObjectType {
+          description: introspection_input_object.description,
+          directives: vec![],
+          name: introspection_input_object.name,
+          position: Default::default(),
+          fields: introspection_input_object
+            .input_fields
+            .into_iter()
+            .map(|introspection_input_field| InputValue {
+              default_value: introspection_input_field
+                .default_value
+                .map(serde_value_to_sdl_value),
+              value_type: introspection_input_field
+                .type_ref
+                .map(|v| introspection_input_typeref_to_sdl_type(&v))
+                .unwrap(),
+              description: introspection_input_field.description,
+              directives: vec![],
+              name: introspection_input_field.name,
+              position: Default::default(),
+            })
+            .collect(),
+        })
+      }
+      IntrospectionType::SCALAR(introspection_scalar) => TypeDefinition::Scalar(ScalarType {
+        position: Default::default(),
+        name: introspection_scalar.name,
+        description: introspection_scalar.description,
+        directives: vec![],
+      }),
+      IntrospectionType::UNION(introspection_union) => TypeDefinition::Union(UnionType {
+        position: Default::default(),
+        name: introspection_union.name,
+        description: introspection_union.description,
+        directives: vec![],
+        types: introspection_union
+          .possible_types
+          .into_iter()
+          .map(|v| v.name)
+          .collect(),
+      }),
+      IntrospectionType::ENUM(introspection_enum) => TypeDefinition::Enum(EnumType {
+        position: Default::default(),
+        name: introspection_enum.name,
+        description: introspection_enum.description,
+        directives: vec![],
+        values: introspection_enum
+          .enum_values
+          .into_iter()
+          .map(|introspection_enum_value| EnumValue {
+            position: Default::default(),
+            name: introspection_enum_value.name,
+            description: introspection_enum_value.description,
+            directives: vec![],
+          })
+          .collect(),
+      }),
+    };
+
+    result
+      .definitions
+      .push(Definition::TypeDefinition(schema_type));
+  }
+
+  result
+}
+
+// Adapted from: https://github.com/graphql/graphql-js/blob/9c90a23dd430ba7b9db3d566b084e9f66aded346/src/utilities/getIntrospectionQuery.ts#L66
+pub static INTROSPECTION_QUERY: &str = r#"query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"#;

--- a/libs/common/src/lib.rs
+++ b/libs/common/src/lib.rs
@@ -1,10 +1,16 @@
 pub mod execute;
 pub mod graphql;
 pub mod http;
+pub mod introspection;
 pub mod json;
 pub mod plugin;
 pub mod plugin_manager;
 pub mod serde_utils;
+pub mod source;
 pub mod vrl_functions;
 pub mod vrl_utils;
 pub use graphql_parser::query::{Definition, Document, OperationDefinition, ParseError};
+pub use graphql_parser::schema::{
+  parse_schema, Document as SchemaDocument, ParseError as SchemaParseError, SchemaDefinition,
+};
+pub use graphql_tools::introspection::parse_introspection_from_string as parse_introspection_str;

--- a/libs/common/src/plugin.rs
+++ b/libs/common/src/plugin.rs
@@ -1,8 +1,9 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use crate::{
   graphql::GraphQLRequest,
   http::{ConductorHttpRequest, ConductorHttpResponse},
+  source::SourceRuntime,
 };
 use reqwest::Response;
 
@@ -30,7 +31,12 @@ pub trait Plugin: Sync + Send + Debug {
   // Step 1: An HTTP request send from the client to Conductor
   async fn on_downstream_http_request(&self, _ctx: &mut RequestExecutionContext) {}
   // Step 2: An incoming GraphQL operation executed to Conductor
-  async fn on_downstream_graphql_request(&self, _ctx: &mut RequestExecutionContext) {}
+  async fn on_downstream_graphql_request(
+    &self,
+    _source_runtime: Arc<Box<dyn SourceRuntime>>,
+    _ctx: &mut RequestExecutionContext,
+  ) {
+  }
   // Step 3: A GraphQL request send from Conductor to the upstream GraphQL server
   async fn on_upstream_graphql_request(&self, _req: &mut GraphQLRequest) {}
   // Step 4: A GraphQL request send from Conductor to the upstream GraphQL server

--- a/libs/common/src/plugin_manager.rs
+++ b/libs/common/src/plugin_manager.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use crate::{
   execute::RequestExecutionContext,
   graphql::GraphQLRequest,
   http::{ConductorHttpRequest, ConductorHttpResponse},
+  source::SourceRuntime,
 };
 use reqwest::Response;
 
@@ -13,7 +16,11 @@ pub trait PluginManager: std::fmt::Debug + Send + Sync {
     context: &mut RequestExecutionContext,
     response: &mut ConductorHttpResponse,
   );
-  async fn on_downstream_graphql_request(&self, context: &mut RequestExecutionContext);
+  async fn on_downstream_graphql_request(
+    &self,
+    source_runtime: Arc<Box<dyn SourceRuntime>>,
+    context: &mut RequestExecutionContext,
+  );
   async fn on_upstream_graphql_request<'a>(&self, req: &mut GraphQLRequest);
   async fn on_upstream_http_request<'a>(
     &self,

--- a/libs/config/Cargo.toml
+++ b/libs/config/Cargo.toml
@@ -26,7 +26,9 @@ vrl_plugin = { path = "../../plugins/vrl" }
 disable_introspection_plugin = { path = "../../plugins/disable_introspection" }
 trusted_documents_plugin = { path = "../../plugins/trusted_documents" }
 graphiql_plugin = { path = "../../plugins/graphiql" }
+graphql_validation_plugin = { path = "../../plugins/graphql_validation" }
 http_get_plugin = { path = "../../plugins/http_get" }
 jwt_auth_plugin = { path = "../../plugins/jwt_auth" }
 humantime-serde = "1.1.1"
 telemetry_plugin = { path = "../../plugins/telemetry" }
+http-serde = "1.1.3"

--- a/libs/config/conductor.schema.json
+++ b/libs/config/conductor.schema.json
@@ -214,7 +214,8 @@
             "title": "Simple"
           },
           "config": {
-            "endpoint": "https://my-source.com/graphql"
+            "endpoint": "https://my-source.com/graphql",
+            "schema_awareness": null
           },
           "id": "my-source",
           "type": "graphql"
@@ -228,8 +229,164 @@
         "endpoint": {
           "description": "The HTTP(S) endpoint URL for the GraphQL source.",
           "type": "string"
+        },
+        "schema_awareness": {
+          "description": "Schema Awareness configuration for the source. Enabling this configuration will configure the gateway to load the upstream GraphQL schema and use that information in other plugins.\n\nWhen this configuration is not specified, Schema Awareness is disabled, and plugins will not have access to the upstream schema. In that case, the gateway will act as a simple proxy, without any knowledge of the upstream schema.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaAwarenessConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
+    },
+    "SchemaAwarenessConfig": {
+      "type": "object",
+      "required": [
+        "format",
+        "source"
+      ],
+      "properties": {
+        "format": {
+          "description": "The expected format of the response/file.",
+          "$ref": "#/definitions/SchemaAwarenessFormat"
+        },
+        "source": {
+          "description": "The source of the schema awareness. Can be either a local file, an inline string (hardcoded or from environment variables), or a remote endpoint.",
+          "$ref": "#/definitions/SchemaAwarenessSource"
+        },
+        "polling_interval": {
+          "description": "Polling interval for reloading the schema awareness.\n\nThis field is ignored on WASM runtime.",
+          "default": "1m",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "on_error": {
+          "description": "What to do in case of a failure to load the schema awareness.",
+          "default": "terminate",
+          "$ref": "#/definitions/SchemaAwarenessConfigOnError"
+        }
+      }
+    },
+    "SchemaAwarenessFormat": {
+      "oneOf": [
+        {
+          "description": "The schema awareness is provided as a GraphQL introspection response.\n\nPlease note that GraphQL introspection does not contain information about GraphWL directives usage, so it's not suitable for runtimes/plugins that rely on directives.",
+          "type": "string",
+          "enum": [
+            "introspection"
+          ]
+        },
+        {
+          "description": "The schema awareness is provided as a GraphQL SDL schema.",
+          "type": "string",
+          "enum": [
+            "sdl"
+          ]
+        }
+      ]
+    },
+    "SchemaAwarenessSource": {
+      "oneOf": [
+        {
+          "description": "Loads schema awareness from a local file.",
+          "type": "object",
+          "required": [
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "path": {
+              "$ref": "#/definitions/LocalFileReference"
+            }
+          }
+        },
+        {
+          "description": "Loads schema awareness from an inline string. You can also use environment variable intropolation in this field.",
+          "type": "object",
+          "required": [
+            "content",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "inline"
+              ]
+            },
+            "content": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Loads schema awareness from a remote endpoint.",
+          "type": "object",
+          "required": [
+            "type",
+            "url"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "remote"
+              ]
+            },
+            "url": {
+              "description": "Endpoint to load the schema awareness from.",
+              "type": "string"
+            },
+            "headers": {
+              "description": "Optional headers to include in the request (for example: authentication).\n\nBy default, when `format: introspection` is used, the gateway will add `Content-Type: application/json` and `Accept: application/json` to the request headers.",
+              "default": {},
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "method": {
+              "description": "HTTP method to use when fetching the schema awareness from the remote endpoint.\n\nBy default, this field is set to `GET`. If you are using `format: introspection`, you should change this property to be `POST`.",
+              "default": "GET",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "LocalFileReference": {
+      "type": "string",
+      "format": "path"
+    },
+    "SchemaAwarenessConfigOnError": {
+      "oneOf": [
+        {
+          "description": "On binary runtime, this configuration will stop the gateway with an error.\n\nOn WASM runtime, this field will return 500 in case of a failure to load.",
+          "type": "string",
+          "enum": [
+            "terminate"
+          ]
+        },
+        {
+          "description": "Ignores the failure and report it to the log, without stopping the gateway or interrupting the execution.",
+          "type": "string",
+          "enum": [
+            "ignore"
+          ]
+        }
+      ]
     },
     "MockedSourceConfig": {
       "description": "A mocked upstream with a static response for all executed operations.",
@@ -243,10 +400,6 @@
         }
       }
     },
-    "LocalFileReference": {
-      "type": "string",
-      "format": "path"
-    },
     "FederationSourceConfig": {
       "description": "A source capable of loading a Supergraph schema based on the [Apollo Federation specification](https://www.apollographql.com/docs/federation/).\n\nThe loaded supergraph will be used to orchestrate the execution of the queries across the federated sources.\n\nThe input for this source can be a local file, an environment variable, or a remote endpoint.\n\nThe content of the Supergraph input needs to be a valid GraphQL SDL schema, with the Apollo Federation execution directives, usually produced by a schema registry.",
       "examples": [
@@ -258,11 +411,15 @@
           "config": {
             "expose_query_plan": false,
             "supergraph": {
-              "remote": {
-                "fetch_every": "10s",
+              "format": "sdl",
+              "on_error": "terminate",
+              "polling_interval": "1m",
+              "source": {
                 "headers": {
-                  "X-Hive-CDN-Key": "CDN_TOKEN"
+                  "x-hive-cdn-key": "CDN_TOKEN"
                 },
+                "method": "GET",
+                "type": "remote",
                 "url": "https://cdn.graphql-hive.com/artifacts/v1/TARGET_ID/supergraph"
               }
             }
@@ -278,21 +435,13 @@
           "config": {
             "expose_query_plan": false,
             "supergraph": {
-              "file": "./supergraph.graphql"
-            }
-          },
-          "id": "my-source",
-          "type": "federation"
-        },
-        {
-          "$metadata": {
-            "description": null,
-            "title": "From Env Var"
-          },
-          "config": {
-            "expose_query_plan": false,
-            "supergraph": {
-              "env": "SUPERGRAPH"
+              "format": "sdl",
+              "on_error": "terminate",
+              "polling_interval": null,
+              "source": {
+                "path": "./supergraph.graphql",
+                "type": "file"
+              }
             }
           },
           "id": "my-source",
@@ -306,108 +455,12 @@
       "properties": {
         "supergraph": {
           "description": "The endpoint URL for the GraphQL source.",
-          "$ref": "#/definitions/SupergraphSourceConfig"
+          "$ref": "#/definitions/SchemaAwarenessConfig"
         },
         "expose_query_plan": {
           "description": "Exposes the query plan as JSON under \"extensions\"",
           "default": false,
           "type": "boolean"
-        }
-      }
-    },
-    "SupergraphSourceConfig": {
-      "oneOf": [
-        {
-          "title": "file",
-          "description": "The file path for the Supergraph schema.\n\n> This provider is not supported on WASM runtime.",
-          "type": "object",
-          "required": [
-            "file"
-          ],
-          "properties": {
-            "file": {
-              "$ref": "#/definitions/LocalFileReference"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "title": "env",
-          "description": "The environment variable that contains the Supergraph schema.",
-          "type": "object",
-          "required": [
-            "env"
-          ],
-          "properties": {
-            "env": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "title": "remote",
-          "description": "The remote endpoint where the Supergraph schema can be fetched.",
-          "type": "object",
-          "required": [
-            "remote"
-          ],
-          "properties": {
-            "remote": {
-              "type": "object",
-              "required": [
-                "url"
-              ],
-              "properties": {
-                "url": {
-                  "description": "The URL endpoint from where to fetch the Supergraph schema.",
-                  "type": "string"
-                },
-                "headers": {
-                  "description": "Optional headers to include in the request (ex: for authentication)",
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                },
-                "fetch_every": {
-                  "description": "Polling interval for fetching the Supergraph schema from the remote.",
-                  "default": "1m",
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/Duration"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "Duration": {
-      "type": "object",
-      "required": [
-        "nanos",
-        "secs"
-      ],
-      "properties": {
-        "secs": {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        "nanos": {
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
         }
       }
     },
@@ -433,7 +486,8 @@
           "sources": [
             {
               "config": {
-                "endpoint": "https://my-source.com/graphql"
+                "endpoint": "https://my-source.com/graphql",
+                "schema_awareness": null
               },
               "id": "my-source",
               "type": "graphql"
@@ -485,7 +539,8 @@
           "sources": [
             {
               "config": {
-                "endpoint": "https://my-source.com/graphql"
+                "endpoint": "https://my-source.com/graphql",
+                "schema_awareness": null
               },
               "id": "my-source",
               "type": "graphql"
@@ -718,6 +773,37 @@
             },
             "config": {
               "$ref": "#/definitions/JwtAuthPluginConfig"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "graphql_validation"
+              ]
+            },
+            "enabled": {
+              "default": true,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/GraphQLValidationPluginConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         },
@@ -1788,6 +1874,9 @@
           }
         }
       ]
+    },
+    "GraphQLValidationPluginConfig": {
+      "type": "object"
     },
     "TelemetryPluginConfig": {
       "description": "The `telemetry` plugin exports traces information about Conductor to a telemetry backend.\n\nThe telemetry plugin exports traces information about the following aspects of Conductor:\n\n- GraphQL parser (timing)\n\n- GraphQL execution (operation type, operation body, operation name, timing, errors)\n\n- Query planning (timing, operation body, operation name)\n\n- Incoming HTTP requests (attributes, timing, errors)\n\n- Outgoing HTTP requests (attributes, timing, errors)\n\nWhen used with a telemtry backend, you can expect to see the following information:\n\n![img](https://raw.githubusercontent.com/the-guild-org/conductor/master/website/public/assets/telemetry.png)",

--- a/libs/config/conductor.schema.json
+++ b/libs/config/conductor.schema.json
@@ -206,7 +206,7 @@
       ]
     },
     "GraphQLSourceConfig": {
-      "description": "An upstream based on a simple, single GraphQL endpoint.\n\nBy using this source, you can easily wrap an existing GraphQL upstream server, and enrich it with features and plugins.",
+      "description": "An upstream based on a simple, single GraphQL endpoint.\n\nBy using this source, you can easily wrap an existing GraphQL upstream server, and enrich it with features and plugins.\n\n## Schema Awareness\n\nThis source supports `schema_awareness` configuration. With schema awareness, the gateway will load the upstream GraphQL schema and use that information during plugins execution.\n\nPlugins can access the schema and provide meaningful features, such as running GraphQL validation as part of the gateway.\n\n> Note: Schema Awareness is optional for the `graphql` source. When it's not specified, the gateway will act as a simple proxy, without any knowledge of the upstream schema. Plugins that rely on the schema will emit a warning and will be skipped.",
       "examples": [
         {
           "$metadata": {
@@ -216,6 +216,70 @@
           "config": {
             "endpoint": "https://my-source.com/graphql",
             "schema_awareness": null
+          },
+          "id": "my-source",
+          "type": "graphql"
+        },
+        {
+          "$metadata": {
+            "description": "This example demonstrates how to enable schema awareness for a GraphQL source. The gateway will load the upstream schema and use that information in other plugins.",
+            "title": "Schema Awareness (remote introspection)"
+          },
+          "config": {
+            "endpoint": "https://my-source.com/graphql",
+            "schema_awareness": {
+              "format": "introspection",
+              "on_error": "terminate",
+              "polling_interval": "1m",
+              "source": {
+                "headers": {
+                  "authorization": "Bearer TOKEN"
+                },
+                "method": "POST",
+                "type": "remote",
+                "url": "https://my-source.com/graphql"
+              }
+            }
+          },
+          "id": "my-source",
+          "type": "graphql"
+        },
+        {
+          "$metadata": {
+            "description": "This example demonstrates how to enable schema awareness for a GraphQL source. The gateway will load the upstream schema and use that information in other plugins.",
+            "title": "Schema Awareness (local sdl)"
+          },
+          "config": {
+            "endpoint": "https://my-source.com/graphql",
+            "schema_awareness": {
+              "format": "sdl",
+              "on_error": "terminate",
+              "polling_interval": null,
+              "source": {
+                "path": "./introspection.json",
+                "type": "file"
+              }
+            }
+          },
+          "id": "my-source",
+          "type": "graphql"
+        },
+        {
+          "$metadata": {
+            "description": "This example demonstrates how to enable schema awareness for a GraphQL source. The gateway will load the upstream schema and use that information in other plugins.",
+            "title": "Schema Awareness (inline)"
+          },
+          "config": {
+            "endpoint": "https://my-source.com/graphql",
+            "schema_awareness": {
+              "format": "sdl",
+              "on_error": "terminate",
+              "polling_interval": null,
+              "source": {
+                "content": "type Query { noop: String }",
+                "type": "inline"
+              }
+            }
           },
           "id": "my-source",
           "type": "graphql"
@@ -276,13 +340,15 @@
     "SchemaAwarenessFormat": {
       "oneOf": [
         {
-          "description": "The schema awareness is provided as a GraphQL introspection response.\n\nPlease note that GraphQL introspection does not contain information about GraphWL directives usage, so it's not suitable for runtimes/plugins that rely on directives.",
+          "title": "introspection",
+          "description": "The schema awareness is provided as a GraphQL introspection response.\n\nPlease note that GraphQL introspection does not contain information about GraphQL directives usage, so it's not suitable for runtimes/plugins that rely on directives.",
           "type": "string",
           "enum": [
             "introspection"
           ]
         },
         {
+          "title": "sdl",
           "description": "The schema awareness is provided as a GraphQL SDL schema.",
           "type": "string",
           "enum": [
@@ -294,6 +360,7 @@
     "SchemaAwarenessSource": {
       "oneOf": [
         {
+          "title": "file",
           "description": "Loads schema awareness from a local file.",
           "type": "object",
           "required": [
@@ -313,6 +380,7 @@
           }
         },
         {
+          "title": "inline",
           "description": "Loads schema awareness from an inline string. You can also use environment variable intropolation in this field.",
           "type": "object",
           "required": [
@@ -332,6 +400,7 @@
           }
         },
         {
+          "title": "remote",
           "description": "Loads schema awareness from a remote endpoint.",
           "type": "object",
           "required": [
@@ -373,6 +442,7 @@
     "SchemaAwarenessConfigOnError": {
       "oneOf": [
         {
+          "title": "terminate",
           "description": "On binary runtime, this configuration will stop the gateway with an error.\n\nOn WASM runtime, this field will return 500 in case of a failure to load.",
           "type": "string",
           "enum": [
@@ -380,6 +450,7 @@
           ]
         },
         {
+          "title": "ignore",
           "description": "Ignores the failure and report it to the log, without stopping the gateway or interrupting the execution.",
           "type": "string",
           "enum": [
@@ -411,8 +482,6 @@
           "config": {
             "expose_query_plan": false,
             "supergraph": {
-              "format": "sdl",
-              "on_error": "terminate",
               "polling_interval": "1m",
               "source": {
                 "headers": {
@@ -435,8 +504,6 @@
           "config": {
             "expose_query_plan": false,
             "supergraph": {
-              "format": "sdl",
-              "on_error": "terminate",
               "polling_interval": null,
               "source": {
                 "path": "./supergraph.graphql",
@@ -455,12 +522,32 @@
       "properties": {
         "supergraph": {
           "description": "The endpoint URL for the GraphQL source.",
-          "$ref": "#/definitions/SchemaAwarenessConfig"
+          "$ref": "#/definitions/SchemaAwarenessSupergraphConfig"
         },
         "expose_query_plan": {
           "description": "Exposes the query plan as JSON under \"extensions\"",
           "default": false,
           "type": "boolean"
+        }
+      }
+    },
+    "SchemaAwarenessSupergraphConfig": {
+      "type": "object",
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "source": {
+          "description": "The source of the schema awareness. Can be either a local file, an inline string (hardcoded or from environment variables), or a remote endpoint.",
+          "$ref": "#/definitions/SchemaAwarenessSource"
+        },
+        "polling_interval": {
+          "description": "Polling interval for reloading the schema awareness.\n\nThis field is ignored on WASM runtime.",
+          "default": "1m",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod interpolate;
 
-use conductor_common::serde_utils::{
-  JsonSchemaExample, JsonSchemaExampleMetadata, LocalFileReference, BASE_PATH,
+use conductor_common::{
+  http::{HttpHeadersMap, Method, ToHeadersMap},
+  serde_utils::{JsonSchemaExample, JsonSchemaExampleMetadata, LocalFileReference, BASE_PATH},
 };
 use conductor_logger::config::LoggerConfigFormat;
 use interpolate::interpolate;
@@ -161,6 +162,7 @@ fn endpoint_definition_example1() -> JsonSchemaExample<ConductorConfig> {
                 id: "my-source".to_string(),
                 config: GraphQLSourceConfig {
                     endpoint: "https://my-source.com/graphql".to_string(),
+                    schema_awareness: None,
                 },
             }],
             endpoints: vec![EndpointDefinition {
@@ -184,6 +186,7 @@ fn endpoint_definition_example2() -> JsonSchemaExample<ConductorConfig> {
                 id: "my-source".to_string(),
                 config: GraphQLSourceConfig {
                     endpoint: "https://my-source.com/graphql".to_string(),
+                    schema_awareness: None,
                 },
             }],
             endpoints: vec![EndpointDefinition {
@@ -294,6 +297,16 @@ pub enum PluginDefinition {
     )]
     enabled: Option<bool>,
     config: jwt_auth_plugin::Config,
+  },
+
+  #[serde(rename = "graphql_validation")]
+  GraphQLValidation {
+    #[serde(
+      default = "default_plugin_enabled",
+      skip_serializing_if = "Option::is_none"
+    )]
+    enabled: Option<bool>,
+    config: Option<graphql_validation_plugin::Config>,
   },
 
   #[serde(rename = "telemetry")]
@@ -442,6 +455,16 @@ pub enum SourceDefinition {
   },
 }
 
+impl SourceDefinition {
+  pub fn id(&self) -> &str {
+    match self {
+      SourceDefinition::GraphQL { id, .. } => id,
+      SourceDefinition::Mock { id, .. } => id,
+      SourceDefinition::Federation { id, .. } => id,
+    }
+  }
+}
+
 /// An upstream based on a simple, single GraphQL endpoint.
 ///
 /// By using this source, you can easily wrap an existing GraphQL upstream server, and enrich it with features and plugins.
@@ -450,6 +473,115 @@ pub enum SourceDefinition {
 pub struct GraphQLSourceConfig {
   /// The HTTP(S) endpoint URL for the GraphQL source.
   pub endpoint: String,
+  /// Schema Awareness configuration for the source.
+  /// Enabling this configuration will configure the gateway to load the upstream GraphQL schema and use that information in other plugins.
+  ///
+  /// When this configuration is not specified, Schema Awareness is disabled, and plugins will not have access to the upstream schema.
+  /// In that case, the gateway will act as a simple proxy, without any knowledge of the upstream schema.
+  pub schema_awareness: Option<SchemaAwarenessConfig>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
+pub enum SchemaAwarenessFormat {
+  /// The schema awareness is provided as a GraphQL introspection response.
+  ///
+  /// Please note that GraphQL introspection does not contain information about GraphWL directives usage, so it's not suitable for runtimes/plugins that rely on directives.
+  #[serde(rename = "introspection")]
+  Introspection,
+  /// The schema awareness is provided as a GraphQL SDL schema.
+  #[serde(rename = "sdl")]
+  Sdl,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
+pub struct SchemaAwarenessConfig {
+  /// The expected format of the response/file.
+  pub format: SchemaAwarenessFormat,
+  /// The source of the schema awareness. Can be either a local file, an inline string (hardcoded or from environment variables), or a remote endpoint.
+  pub source: SchemaAwarenessSource,
+  #[serde(
+    deserialize_with = "humantime_serde::deserialize",
+    serialize_with = "humantime_serde::serialize",
+    default = "default_schema_awareness_polling_interval"
+  )]
+  #[schemars(with = "Option<String>")]
+  /// Polling interval for reloading the schema awareness.
+  ///
+  /// This field is ignored on WASM runtime.
+  pub polling_interval: Option<Duration>,
+  /// What to do in case of a failure to load the schema awareness.
+  #[serde(default = "default_schema_awareness_on_error")]
+  pub on_error: SchemaAwarenessConfigOnError,
+}
+
+fn default_schema_awareness_on_error() -> SchemaAwarenessConfigOnError {
+  SchemaAwarenessConfigOnError::Terminate
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
+pub enum SchemaAwarenessConfigOnError {
+  /// On binary runtime, this configuration will stop the gateway with an error.
+  ///
+  /// On WASM runtime, this field will return 500 in case of a failure to load.
+  #[serde(rename = "terminate")]
+  Terminate,
+  /// Ignores the failure and report it to the log, without stopping the gateway or interrupting the execution.
+  #[serde(rename = "ignore")]
+  Ignore,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn default_schema_awareness_polling_interval() -> Option<Duration> {
+  Some(Duration::from_secs(60))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn default_schema_awareness_polling_interval() -> Option<Duration> {
+  None
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
+#[serde(tag = "type")]
+pub enum SchemaAwarenessSource {
+  #[serde(rename = "file")]
+  /// Loads schema awareness from a local file.
+  File {
+    #[serde(rename = "path")]
+    file: LocalFileReference,
+  },
+  /// Loads schema awareness from an inline string. You can also use environment variable intropolation in this field.
+  #[serde(rename = "inline")]
+  Inline { content: String },
+  /// Loads schema awareness from a remote endpoint.
+  #[serde(rename = "remote")]
+  Remote {
+    /// Endpoint to load the schema awareness from.
+    url: String,
+    #[serde(
+      deserialize_with = "http_serde::header_map::deserialize",
+      serialize_with = "http_serde::header_map::serialize",
+      default
+    )]
+    /// Optional headers to include in the request (for example: authentication).
+    ///
+    /// By default, when `format: introspection` is used, the gateway will add `Content-Type: application/json` and `Accept: application/json` to the request headers.
+    #[schemars(with = "HashMap<String, String>")]
+    headers: HttpHeadersMap,
+    /// HTTP method to use when fetching the schema awareness from the remote endpoint.
+    ///
+    /// By default, this field is set to `GET`. If you are using `format: introspection`, you should change this property to be `POST`.
+    #[serde(
+      deserialize_with = "http_serde::method::deserialize",
+      serialize_with = "http_serde::method::serialize",
+      default = "default_schema_awareness_remote_method"
+    )]
+    #[schemars(with = "String")]
+    method: Method,
+  },
+}
+
+fn default_schema_awareness_remote_method() -> Method {
+  Method::GET
 }
 
 /// A mocked upstream with a static response for all executed operations.
@@ -466,6 +598,7 @@ fn graphql_source_definition_example() -> JsonSchemaExample<SourceDefinition> {
       id: "my-source".to_string(),
       config: GraphQLSourceConfig {
         endpoint: "https://my-source.com/graphql".to_string(),
+        schema_awareness: None,
       },
     },
   }
@@ -481,10 +614,9 @@ fn graphql_source_definition_example() -> JsonSchemaExample<SourceDefinition> {
 #[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
 #[schemars(example = "federation_definition_example1")]
 #[schemars(example = "federation_definition_example2")]
-#[schemars(example = "federation_definition_example3")]
 pub struct FederationSourceConfig {
   /// The endpoint URL for the GraphQL source.
-  pub supergraph: SupergraphSourceConfig,
+  pub supergraph: SchemaAwarenessConfig,
   /// Exposes the query plan as JSON under "extensions"
   #[serde(default = "default_expose_query_plan")]
   pub expose_query_plan: bool,
@@ -506,14 +638,17 @@ fn federation_definition_example1() -> JsonSchemaExample<SourceDefinition> {
     example: SourceDefinition::Federation {
       id: "my-source".to_string(),
       config: FederationSourceConfig {
-        supergraph: SupergraphSourceConfig::Remote {
-          fetch_every: Some(Duration::from_secs(10)),
-          url: "https://cdn.graphql-hive.com/artifacts/v1/TARGET_ID/supergraph".to_string(),
-          headers: Some(
-            [("X-Hive-CDN-Key".to_string(), "CDN_TOKEN".to_string())]
-              .into_iter()
-              .collect::<HashMap<_, _>>(),
-          ),
+        supergraph: SchemaAwarenessConfig {
+          on_error: SchemaAwarenessConfigOnError::Terminate,
+          polling_interval: Some(Duration::from_secs(60)),
+          format: SchemaAwarenessFormat::Sdl,
+          source: SchemaAwarenessSource::Remote {
+            url: "https://cdn.graphql-hive.com/artifacts/v1/TARGET_ID/supergraph".to_string(),
+            headers: vec![("X-Hive-CDN-Key", "CDN_TOKEN")]
+              .to_headers_map()
+              .unwrap(),
+            method: Method::GET,
+          },
         },
         expose_query_plan: false,
       },
@@ -528,25 +663,18 @@ fn federation_definition_example2() -> JsonSchemaExample<SourceDefinition> {
     example: SourceDefinition::Federation {
       id: "my-source".to_string(),
       config: FederationSourceConfig {
-        supergraph: SupergraphSourceConfig::File(LocalFileReference {
-          contents: "".into(),
-          path: "./supergraph.graphql".into(),
-        }),
+        supergraph: SchemaAwarenessConfig {
+          on_error: SchemaAwarenessConfigOnError::Terminate,
+          polling_interval: None,
+          format: SchemaAwarenessFormat::Sdl,
+          source: SchemaAwarenessSource::File {
+            file: LocalFileReference {
+              contents: "".into(),
+              path: "./supergraph.graphql".into(),
+            },
+          },
+        },
         expose_query_plan: false,
-      },
-    },
-  }
-}
-
-fn federation_definition_example3() -> JsonSchemaExample<SourceDefinition> {
-  JsonSchemaExample {
-    wrapper: None,
-    metadata: JsonSchemaExampleMetadata::new("From Env Var", None),
-    example: SourceDefinition::Federation {
-      id: "my-source".to_string(),
-      config: FederationSourceConfig {
-        expose_query_plan: false,
-        supergraph: SupergraphSourceConfig::EnvVar("SUPERGRAPH".into()),
       },
     },
   }

--- a/libs/e2e_tests/suite.rs
+++ b/libs/e2e_tests/suite.rs
@@ -29,8 +29,11 @@ impl TestSuite {
       "test".to_string(),
       GraphQLSourceConfig {
         endpoint: mock_server.url("/graphql"),
+        schema_awareness: None,
       },
-    );
+    )
+    .await
+    .expect("failed to create source");
 
     let response =
       ConductorGateway::execute_test(Arc::new(Box::new(source)), self.plugins, request).await;
@@ -62,8 +65,11 @@ impl TestSuite {
       "test".to_string(),
       GraphQLSourceConfig {
         endpoint: mock_server.url("/graphql"),
+        schema_awareness: None,
       },
-    );
+    )
+    .await
+    .expect("failed to create source");
 
     ConductorGateway::execute_test(Arc::new(Box::new(source)), self.plugins, request).await
   }

--- a/libs/e2e_tests/tests/plugin_disable_introspection.rs
+++ b/libs/e2e_tests/tests/plugin_disable_introspection.rs
@@ -1,114 +1,12 @@
 use conductor_common::{
   graphql::GraphQLRequest,
   http::{ConductorHttpRequest, HttpHeadersMap, Method},
+  introspection::INTROSPECTION_QUERY,
   plugin::CreatablePlugin,
   vrl_utils::VrlConfigReference,
 };
 use e2e::suite::TestSuite;
 use tokio::test;
-
-static INTROSPECTION_QUERY: &str = r#"
-    query IntrospectionQuery {
-        __schema {
-          queryType { name }
-          mutationType { name }
-          subscriptionType { name }
-          types {
-            ...FullType
-          }
-          directives {
-            name
-            description
-            locations
-            args {
-              ...InputValue
-            }
-          }
-        }
-      }
-
-      fragment FullType on __Type {
-        kind
-        name
-        description
-
-        fields(includeDeprecated: true) {
-          name
-          description
-          args {
-            ...InputValue
-          }
-          type {
-            ...TypeRef
-          }
-          isDeprecated
-          deprecationReason
-        }
-        inputFields {
-          ...InputValue
-        }
-        interfaces {
-          ...TypeRef
-        }
-        enumValues(includeDeprecated: true) {
-          name
-          description
-          isDeprecated
-          deprecationReason
-        }
-        possibleTypes {
-          ...TypeRef
-        }
-      }
-
-      fragment InputValue on __InputValue {
-        name
-        description
-        type { ...TypeRef }
-        defaultValue
-      }
-
-      fragment TypeRef on __Type {
-        kind
-        name
-        ofType {
-          kind
-          name
-          ofType {
-            kind
-            name
-            ofType {
-              kind
-              name
-              ofType {
-                kind
-                name
-                ofType {
-                  kind
-                  name
-                  ofType {
-                    kind
-                    name
-                    ofType {
-                      kind
-                      name
-                      ofType {
-                        kind
-                        name
-                        ofType {
-                          kind
-                          name
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    "#;
 
 #[test]
 async fn should_allow_introspection_without_plugin() {

--- a/libs/engine/Cargo.toml
+++ b/libs/engine/Cargo.toml
@@ -37,6 +37,7 @@ vrl_plugin = { path = "../../plugins/vrl" }
 jwt_auth_plugin = { path = "../../plugins/jwt_auth" }
 federation_query_planner = { path = "../../libs/federation_query_planner" }
 telemetry_plugin = { path = "../../plugins/telemetry" }
+graphql_validation_plugin = { path = "../../plugins/graphql_validation" }
 minitrace = { workspace = true }
 minitrace_reqwest = { path = "../minitrace_reqwest" }
 

--- a/libs/engine/src/lib.rs
+++ b/libs/engine/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod gateway;
 pub mod plugin_manager;
+pub mod schema_awareness;
 pub mod source;

--- a/libs/engine/src/schema_awareness.rs
+++ b/libs/engine/src/schema_awareness.rs
@@ -1,0 +1,337 @@
+use std::{
+  ops::Deref,
+  sync::{Arc, RwLock, RwLockReadGuard},
+};
+
+use conductor_common::{
+  graphql::{parse_graphql_schema, GraphQLRequest, GraphQLResponse, ParsedGraphQLSchema},
+  http::HttpHeadersMap,
+  introspection::{introspection_to_sdl, IntrospectionQueryResponse, INTROSPECTION_QUERY},
+  parse_introspection_str, SchemaParseError,
+};
+use conductor_config::{
+  SchemaAwarenessConfig, SchemaAwarenessConfigOnError, SchemaAwarenessFormat, SchemaAwarenessSource,
+};
+use reqwest::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
+use wasm_polyfills::create_http_client;
+
+#[derive(Debug)]
+pub struct SchemaAwarenessRecord<ProcessedValue> {
+  raw: Arc<String>,
+  schema: Arc<ParsedGraphQLSchema>,
+  processed: Arc<ProcessedValue>,
+}
+
+impl<ProcessedValue> SchemaAwarenessRecord<ProcessedValue> {
+  pub fn raw(&self) -> &Arc<String> {
+    &self.raw
+  }
+
+  pub fn schema(&self) -> &Arc<ParsedGraphQLSchema> {
+    &self.schema
+  }
+
+  pub fn processed(&self) -> &Arc<ProcessedValue> {
+    &self.processed
+  }
+}
+
+type ProcessorFn<ProcessedValue> =
+  fn(raw: &str, parsed: &ParsedGraphQLSchema) -> Result<ProcessedValue, anyhow::Error>;
+
+#[derive(Debug)]
+pub struct SchemaAwareness<ProcessedValue = ()> {
+  schema: Arc<RwLock<Option<Arc<SchemaAwarenessRecord<ProcessedValue>>>>>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum SchemaAwarenessError {
+  #[error("failed to fetch remote schema")]
+  FailedToFetchRemoteSchema { source: reqwest::Error },
+  #[error("failed to read remote body")]
+  FailedToReadRemoteBody { source: reqwest::Error },
+  #[error("failed to parse schema")]
+  FailedToParseSchema { source: SchemaParseError },
+  #[error("failed to process")]
+  FailedToProcessSchema { source: anyhow::Error },
+  #[error("failed to load introspection")]
+  FailedToParseIntrospection { source: Option<serde_json::Error> },
+}
+
+impl<ProcessedValue> SchemaAwareness<ProcessedValue>
+where
+  ProcessedValue: Send + Sync + 'static,
+{
+  pub async fn new(
+    source_id: String,
+    config: SchemaAwarenessConfig,
+    processor: ProcessorFn<ProcessedValue>,
+  ) -> Result<Self, SchemaAwarenessError> {
+    tracing::info!("Initializing schema awareness for source '{}'", source_id);
+    let initial_schema = match Self::load_schema(&config.format, &config.source, processor).await {
+      Ok(schema) => Some(Arc::new(schema)),
+      Err(e) => {
+        tracing::error!(
+          "Failed to load initial schema awareness for id '{}': {:?}",
+          source_id,
+          e
+        );
+
+        match config.on_error {
+          SchemaAwarenessConfigOnError::Ignore => {
+            tracing::error!(
+              "Failed to load schema awareness for source '{}'. Ignoring.",
+              source_id
+            );
+
+            None
+          }
+          SchemaAwarenessConfigOnError::Terminate => {
+            return Err(e);
+          }
+        }
+      }
+    };
+
+    let instance = Self {
+      schema: Arc::new(RwLock::new(initial_schema)),
+    };
+
+    if let Some(_polling_interval_duration) = config.polling_interval {
+      #[cfg(target_arch = "wasm32")]
+      {
+        tracing::error!(
+          "Schema awareness polling interval is not supported in WASM runtime, ignoring."
+        )
+      }
+
+      #[cfg(not(target_arch = "wasm32"))]
+      {
+        let source_id = source_id.clone();
+        let source = config.source.clone();
+        let format = config.format.clone();
+        let handle = instance.schema.clone();
+
+        tokio::spawn(async move {
+          Self::fetch_periodically(
+            source_id,
+            format,
+            source,
+            handle,
+            processor,
+            _polling_interval_duration,
+          )
+          .await;
+        });
+      }
+    }
+
+    Ok(instance)
+  }
+
+  #[cfg(not(target_arch = "wasm32"))]
+  async fn fetch_periodically(
+    source_id: String,
+    format: SchemaAwarenessFormat,
+    source: SchemaAwarenessSource,
+    handle: Arc<RwLock<Option<Arc<SchemaAwarenessRecord<ProcessedValue>>>>>,
+    processor: ProcessorFn<ProcessedValue>,
+    duration: std::time::Duration,
+  ) {
+    let mut interval_timer = tokio::time::interval(duration);
+
+    loop {
+      interval_timer.tick().await;
+      Self::load_and_update_schema(
+        source_id.clone(),
+        format.clone(),
+        source.clone(),
+        handle.clone(),
+        processor,
+      )
+      .await;
+    }
+  }
+
+  #[cfg(not(target_arch = "wasm32"))]
+  async fn load_and_update_schema(
+    source_id: String,
+    format: SchemaAwarenessFormat,
+    source: SchemaAwarenessSource,
+    handle: Arc<RwLock<Option<Arc<SchemaAwarenessRecord<ProcessedValue>>>>>,
+    processor: ProcessorFn<ProcessedValue>,
+  ) {
+    tracing::debug!(
+      "fetching schema awareness for source '{}', format: {:?} source config: {:?}",
+      source_id,
+      format,
+      source
+    );
+    let schema = Self::load_schema(&format, &source, processor).await;
+
+    match schema {
+      Ok(schema) => match handle.write() {
+        Ok(mut t) => {
+          tracing::debug!(
+            "successfully loaded schema awareness for source '{}', updating local record",
+            source_id
+          );
+          t.replace(Arc::new(schema));
+        }
+        Err(e) => {
+          tracing::error!(
+            "Failed to accquire lock for schema awareness for source '{}': {:?}",
+            source_id,
+            e
+          );
+        }
+      },
+      Err(e) => tracing::error!(
+        "Failed to load schema awareness for id '{}': {:?}",
+        source_id,
+        e
+      ),
+    };
+  }
+
+  async fn load_schema<'a>(
+    format: &'a SchemaAwarenessFormat,
+    source: &'a SchemaAwarenessSource,
+    processor: ProcessorFn<ProcessedValue>,
+  ) -> Result<SchemaAwarenessRecord<ProcessedValue>, SchemaAwarenessError> {
+    let result = match (format, source) {
+      (SchemaAwarenessFormat::Sdl, SchemaAwarenessSource::File { file }) => {
+        parse_graphql_schema(&file.contents).map(|schema| (file.contents.clone(), schema))
+      }
+      (SchemaAwarenessFormat::Sdl, SchemaAwarenessSource::Inline { content }) => {
+        parse_graphql_schema(&content).map(|schema| (content.clone(), schema))
+      }
+      (
+        SchemaAwarenessFormat::Sdl,
+        SchemaAwarenessSource::Remote {
+          url,
+          headers,
+          method,
+        },
+      ) => {
+        let http_client = create_http_client().build().unwrap();
+        let res = http_client
+          .request(method.clone(), url)
+          .headers(headers.clone())
+          .send()
+          .await
+          .map_err(|source| SchemaAwarenessError::FailedToFetchRemoteSchema { source })?
+          .text()
+          .await
+          .map_err(|source| SchemaAwarenessError::FailedToReadRemoteBody { source })?;
+
+        parse_graphql_schema(&res).map(|schema| (res, schema))
+      }
+      (
+        SchemaAwarenessFormat::Introspection,
+        SchemaAwarenessSource::Remote {
+          url,
+          headers,
+          method,
+        },
+      ) => {
+        let http_client = create_http_client().build().unwrap();
+        let mut headers = HttpHeadersMap::from(headers.clone());
+        headers
+          .entry(CONTENT_TYPE)
+          .or_insert(HeaderValue::from_static("application/json"));
+        headers
+          .entry(ACCEPT)
+          .or_insert(HeaderValue::from_static("application/json"));
+
+        let gql_response = http_client
+          .request(method.clone(), url)
+          .headers(headers.clone())
+          .body(
+            GraphQLRequest {
+              operation: INTROSPECTION_QUERY.to_string(),
+              operation_name: Some(String::from("IntrospectionQuery")),
+              extensions: None,
+              variables: None,
+            }
+            .to_string(),
+          )
+          .send()
+          .await
+          .map_err(|source| SchemaAwarenessError::FailedToFetchRemoteSchema { source })?
+          .json::<GraphQLResponse<IntrospectionQueryResponse>>()
+          .await
+          .map_err(|source| SchemaAwarenessError::FailedToReadRemoteBody { source })?;
+
+        match gql_response.data {
+          None => return Err(SchemaAwarenessError::FailedToParseIntrospection { source: None }),
+          Some(data) => {
+            let as_sdl_obj = introspection_to_sdl(data);
+
+            Ok((as_sdl_obj.to_string(), as_sdl_obj))
+          }
+        }
+      }
+      (SchemaAwarenessFormat::Introspection, SchemaAwarenessSource::File { file }) => {
+        let introspection = parse_introspection_str(&file.contents).map_err(|source| {
+          SchemaAwarenessError::FailedToParseIntrospection {
+            source: Some(source),
+          }
+        })?;
+
+        let as_sdl_obj = introspection_to_sdl(introspection);
+
+        Ok((as_sdl_obj.to_string(), as_sdl_obj))
+      }
+      (SchemaAwarenessFormat::Introspection, SchemaAwarenessSource::Inline { content }) => {
+        let introspection = parse_introspection_str(&content).map_err(|source| {
+          SchemaAwarenessError::FailedToParseIntrospection {
+            source: Some(source),
+          }
+        })?;
+
+        let as_sdl_obj = introspection_to_sdl(introspection);
+
+        Ok((as_sdl_obj.to_string(), as_sdl_obj))
+      }
+    }
+    .map_err(|source| SchemaAwarenessError::FailedToParseSchema { source })?;
+
+    let processed = processor(&result.0, &result.1)
+      .map_err(|source| SchemaAwarenessError::FailedToProcessSchema { source })?;
+
+    Ok(SchemaAwarenessRecord {
+      raw: Arc::new(result.0),
+      schema: Arc::new(result.1),
+      processed: Arc::new(processed),
+    })
+  }
+
+  fn record(&self) -> RwLockReadGuard<Option<Arc<SchemaAwarenessRecord<ProcessedValue>>>> {
+    self.schema.read().unwrap()
+  }
+
+  pub fn schema(&self) -> Option<Arc<ParsedGraphQLSchema>> {
+    if let Some(record) = self.record().deref() {
+      return Some(record.schema().clone());
+    }
+
+    None
+  }
+
+  pub fn raw(&self) -> Option<Arc<String>> {
+    if let Some(record) = self.record().deref() {
+      return Some(record.raw().clone());
+    }
+
+    None
+  }
+
+  pub fn processed(&self) -> Option<Arc<ProcessedValue>> {
+    if let Some(record) = self.record().deref() {
+      return Some(record.processed().clone());
+    }
+
+    None
+  }
+}

--- a/libs/engine/src/source/federation_source.rs
+++ b/libs/engine/src/source/federation_source.rs
@@ -3,7 +3,7 @@ use conductor_common::execute::RequestExecutionContext;
 use conductor_common::graphql::GraphQLResponse;
 use conductor_common::plugin_manager::PluginManager;
 use conductor_common::source::{GraphQLSourceInitError, SourceError, SourceRuntime};
-use conductor_config::FederationSourceConfig;
+use conductor_config::{FederationSourceConfig, SchemaAwarenessConfig};
 use federation_query_planner::supergraph::parse_supergraph;
 use federation_query_planner::supergraph::Supergraph;
 use federation_query_planner::FederationExecutor;
@@ -39,7 +39,12 @@ impl FederationSourceRuntime {
 
     let schema_awareness = SchemaAwareness::<Supergraph>::new(
       identifier.clone(),
-      config.supergraph.to_owned(),
+      SchemaAwarenessConfig {
+        format: conductor_config::SchemaAwarenessFormat::Sdl,
+        on_error: conductor_config::SchemaAwarenessConfigOnError::Terminate,
+        polling_interval: config.supergraph.polling_interval,
+        source: config.supergraph.source.clone(),
+      },
       |_, parsed| parse_supergraph(parsed),
     )
     .await

--- a/libs/engine/src/source/federation_source.rs
+++ b/libs/engine/src/source/federation_source.rs
@@ -1,14 +1,14 @@
-use super::runtime::{SourceError, SourceRuntime};
-use crate::gateway::ConductorGatewayRouteData;
-use base64::{engine, Engine};
+use crate::schema_awareness::SchemaAwareness;
 use conductor_common::execute::RequestExecutionContext;
 use conductor_common::graphql::GraphQLResponse;
-use conductor_config::{FederationSourceConfig, SupergraphSourceConfig};
-use federation_query_planner::supergraph::{parse_supergraph, Supergraph};
+use conductor_common::plugin_manager::PluginManager;
+use conductor_common::source::{GraphQLSourceInitError, SourceError, SourceRuntime};
+use conductor_config::FederationSourceConfig;
+use federation_query_planner::supergraph::parse_supergraph;
+use federation_query_planner::supergraph::Supergraph;
 use federation_query_planner::FederationExecutor;
 use futures::lock::Mutex;
 use minitrace_reqwest::{traced_reqwest, TracedHttpClient};
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 
@@ -17,171 +17,42 @@ pub struct FederationSourceRuntime {
   pub client: TracedHttpClient,
   pub identifier: String,
   pub config: FederationSourceConfig,
-  pub supergraph: Supergraph,
-}
-
-#[cfg(target_arch = "wasm32")]
-pub fn fetch_supergraph_schema(
-  _url: &str,
-  _headers: Option<&HashMap<String, String>>,
-) -> Result<String, String> {
-  panic!(
-    "Remote supergraph source not supported in wasm32 at the moment, please fetch it from ENV"
-  );
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub fn fetch_supergraph_schema(
-  url: &str,
-  headers: Option<&HashMap<String, String>>,
-) -> Result<String, String> {
-  let agent = ureq::Agent::new();
-
-  let mut request = agent.request("POST", url);
-
-  if let Some(headers_map) = headers {
-    for (header_name, header_value) in headers_map {
-      request = request.set(header_name, header_value);
-    }
-  }
-
-  match request.call() {
-    Ok(response) => {
-      if response.status() == 200 {
-        match response.into_string() {
-          Ok(text) => Ok(text),
-          Err(e) => Err(format!("Failed to read response text: {}", e)),
-        }
-      } else {
-        Err(format!(
-          "HTTP request failed with status: {}",
-          response.status()
-        ))
-      }
-    }
-    Err(e) => Err(format!("HTTP request failed: {}", e)),
-  }
-}
-
-#[tracing::instrument(level = "trace")]
-pub fn load_supergraph(
-  config: &FederationSourceConfig, // Add the config parameter here
-) -> Result<Supergraph, Box<dyn std::error::Error>> {
-  match &config.supergraph {
-    SupergraphSourceConfig::File(file_ref) => {
-      let content = std::fs::read_to_string(&file_ref.path)?;
-      Ok(parse_supergraph(&content).unwrap())
-    }
-    SupergraphSourceConfig::EnvVar(env_var) => {
-      let value = std::env::var(env_var)?;
-      let decoded = engine::general_purpose::STANDARD_NO_PAD.decode(value)?;
-      let content = String::from_utf8(decoded)?;
-      Ok(parse_supergraph(&content).unwrap())
-    }
-    #[cfg(target_arch = "wasm32")]
-    SupergraphSourceConfig::Remote {
-      url: _,
-      headers: _,
-      fetch_every: _,
-    } => {
-      panic!(
-        "Remote supergraph source not supported in wasm32 at the moment, please fetch it from ENV"
-      );
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    SupergraphSourceConfig::Remote {
-      url,
-      headers,
-      fetch_every,
-    } => {
-      // Perform the initial fetch
-      let supergraph_schema = fetch_supergraph_schema(url, headers.as_ref())?;
-      let supergraph = parse_supergraph(&supergraph_schema).unwrap();
-
-      // If `fetch_every` is set, start the periodic fetch
-      if let Some(interval) = fetch_every {
-        tracing::info!(
-          "Registered supergraph schema fetch interval to update every: {:?}",
-          interval
-        );
-        let client = wasm_polyfills::create_http_client()
-          .build()
-          .unwrap_or_else(|_| {
-            // @expected: without a fetcher, there's no executor, without an executor, there's no gateway.
-            panic!("Failed while initializing the executor's fetcher for Federation source");
-          });
-
-        let mut runtime = FederationSourceRuntime {
-          client: traced_reqwest(client),
-          identifier: "test".to_string(),
-          config: config.clone(),
-          supergraph: supergraph.clone(),
-        };
-        let url = url.clone();
-        let headers = headers.clone();
-
-        let interval_spawn = *interval;
-        tokio::spawn(async move {
-          runtime
-            .start_periodic_fetch(url, headers, interval_spawn)
-            .await;
-        });
-      }
-
-      Ok(supergraph)
-    }
-  }
+  pub schema_awareness: SchemaAwareness<Supergraph>,
 }
 
 impl FederationSourceRuntime {
-  pub fn new(identifier: String, config: FederationSourceConfig) -> Self {
-    let client = wasm_polyfills::create_http_client()
-      .build()
-      .unwrap_or_else(|_| {
-        // @expected: without a fetcher, there's no executor, without an executor, there's no gateway.
-        panic!("Failed while initializing the executor's fetcher for Federation source");
-      });
+  pub async fn new(
+    identifier: String,
+    config: FederationSourceConfig,
+  ) -> Result<Self, GraphQLSourceInitError> {
+    tracing::info!(
+      "Initializing source '{}' of type 'graphql' with config: {:?}",
+      identifier,
+      config
+    );
 
-    let fetcher = traced_reqwest(client);
+    let client = traced_reqwest(
+      wasm_polyfills::create_http_client()
+        .build()
+        .map_err(|source| GraphQLSourceInitError::FetcherError { source })?,
+    );
 
-    let supergraph = match load_supergraph(&config) {
-      Ok(e) => e,
-      Err(e) => panic!("{e}"),
-    };
+    let schema_awareness = SchemaAwareness::<Supergraph>::new(
+      identifier.clone(),
+      config.supergraph.to_owned(),
+      |_, parsed| parse_supergraph(parsed),
+    )
+    .await
+    .map_err(|source| GraphQLSourceInitError::SourceInitFailed {
+      source: source.into(),
+    })?;
 
-    Self {
-      client: fetcher,
+    Ok(Self {
+      schema_awareness,
+      client,
       identifier,
       config,
-      supergraph,
-    }
-  }
-
-  pub async fn update_supergraph(&mut self, new_schema: String) {
-    let new_supergraph: Supergraph = parse_supergraph(&new_schema).unwrap();
-    self.supergraph = new_supergraph;
-  }
-
-  #[cfg(not(target_arch = "wasm32"))]
-  pub async fn start_periodic_fetch(
-    &mut self,
-    url: String,
-    headers: Option<HashMap<String, String>>,
-    interval: std::time::Duration,
-  ) {
-    let mut interval_timer = tokio::time::interval(interval);
-
-    loop {
-      interval_timer.tick().await;
-      tracing::info!("Fetching new supergraph schema from {url}...");
-      match fetch_supergraph_schema(&url, headers.as_ref()) {
-        Ok(new_schema) => {
-          self.update_supergraph(new_schema).await;
-          tracing::info!("Successfully updated supergraph schema after being fetched from {url}");
-        }
-        Err(e) => eprintln!("Failed to fetch supergraph schema: {:?}", e),
-      }
-    }
+    })
   }
 }
 
@@ -190,9 +61,17 @@ impl SourceRuntime for FederationSourceRuntime {
     &self.identifier
   }
 
+  fn schema(&self) -> Option<Arc<conductor_common::graphql::ParsedGraphQLSchema>> {
+    self.schema_awareness.schema()
+  }
+
+  fn sdl(&self) -> Option<Arc<String>> {
+    self.schema_awareness.raw()
+  }
+
   fn execute<'a>(
     &'a self,
-    route_data: &'a ConductorGatewayRouteData,
+    plugin_manager: Arc<Box<dyn PluginManager>>,
     request_context: &'a mut RequestExecutionContext,
   ) -> Pin<Box<(dyn Future<Output = Result<GraphQLResponse, SourceError>> + 'a)>> {
     Box::pin(wasm_polyfills::call_async(async move {
@@ -202,32 +81,40 @@ impl SourceRuntime for FederationSourceRuntime {
         .expect("GraphQL request isn't available at the time of execution");
 
       let operation = downstream_request.parsed_operation;
-      let executor = FederationExecutor {
-        client: &self.client,
-        plugin_manager: route_data.plugin_manager.clone(),
-        supergraph: &self.supergraph,
-      };
 
-      match executor
-        .execute_federation(Arc::new(Mutex::new(request_context)), operation)
-        .await
-      {
-        Ok((response_data, query_plan)) => {
-          let mut response = serde_json::from_str::<GraphQLResponse>(&response_data).unwrap();
+      match self.schema_awareness.processed().as_ref() {
+        Some(supergraph) => {
+          let executor = FederationExecutor {
+            client: &self.client,
+            plugin_manager: plugin_manager.clone(),
+            supergraph,
+          };
 
-          if self.config.expose_query_plan {
-            let mut ext = serde_json::Map::new();
-            ext.insert(
-              "queryPlan".to_string(),
-              serde_json::value::to_value(query_plan).unwrap(),
-            );
+          match executor
+            .execute_federation(Arc::new(Mutex::new(request_context)), operation)
+            .await
+          {
+            Ok((response_data, query_plan)) => {
+              let mut response = serde_json::from_str::<GraphQLResponse>(&response_data).unwrap();
 
-            response.append_extensions(ext);
+              if self.config.expose_query_plan {
+                let mut ext = serde_json::Map::new();
+                ext.insert(
+                  "queryPlan".to_string(),
+                  serde_json::value::to_value(query_plan).unwrap(),
+                );
+
+                response.append_extensions(ext);
+              }
+
+              Ok(response)
+            }
+            Err(e) => Err(SourceError::UpstreamPlanningError(e)),
           }
-
-          Ok(response)
         }
-        Err(e) => Err(SourceError::UpstreamPlanningError(e)),
+        None => Err(SourceError::UpstreamPlanningError(anyhow::anyhow!(
+          "Upstream planning error: schema awareness is not available!"
+        ))),
       }
     }))
   }

--- a/libs/engine/src/source/mock_source.rs
+++ b/libs/engine/src/source/mock_source.rs
@@ -1,7 +1,9 @@
-use conductor_common::graphql::GraphQLResponse;
+use std::sync::Arc;
+
+use conductor_common::{graphql::GraphQLResponse, plugin_manager::PluginManager};
 use conductor_config::MockedSourceConfig;
 
-use super::runtime::SourceRuntime;
+use conductor_common::source::SourceRuntime;
 
 #[derive(Debug)]
 pub struct MockedSourceRuntime {
@@ -20,14 +22,25 @@ impl SourceRuntime for MockedSourceRuntime {
     &self.identifier
   }
 
+  fn schema(&self) -> Option<std::sync::Arc<conductor_common::graphql::ParsedGraphQLSchema>> {
+    None
+  }
+
+  fn sdl(&self) -> Option<std::sync::Arc<String>> {
+    None
+  }
+
   fn execute<'a>(
     &'a self,
-    _route_data: &'a crate::gateway::ConductorGatewayRouteData,
+    _plugin_manager: Arc<Box<dyn PluginManager>>,
     _request_context: &'a mut conductor_common::execute::RequestExecutionContext,
   ) -> std::pin::Pin<
     Box<
       (dyn futures::prelude::Future<
-        Output = Result<conductor_common::graphql::GraphQLResponse, super::runtime::SourceError>,
+        Output = Result<
+          conductor_common::graphql::GraphQLResponse,
+          conductor_common::source::SourceError,
+        >,
       > + 'a),
     >,
   > {

--- a/libs/engine/src/source/mod.rs
+++ b/libs/engine/src/source/mod.rs
@@ -1,4 +1,3 @@
 pub mod federation_source;
 pub mod graphql_source;
 pub mod mock_source;
-pub mod runtime;

--- a/libs/federation_query_planner/Cargo.toml
+++ b/libs/federation_query_planner/Cargo.toml
@@ -14,7 +14,7 @@ conductor_common = { path = "../common" }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
-graphql-parser = "0.4.0"
+graphql-parser = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 linked-hash-map = "0.5.6"
 futures = { workspace = true }

--- a/libs/federation_query_planner/src/lib.rs
+++ b/libs/federation_query_planner/src/lib.rs
@@ -284,6 +284,7 @@ impl<'a> FederationExecutor<'a> {
 
 #[cfg(test)]
 mod tests {
+  use conductor_common::graphql::parse_graphql_schema;
 
   #[tokio::test]
   async fn generates_query_plan() {
@@ -447,7 +448,8 @@ mod tests {
   "#
     .to_string();
 
-    let _supergraph = parse_supergraph(&supergraph_schema).unwrap();
+    let schema = parse_graphql_schema(&supergraph_schema).unwrap();
+    let _supergraph = parse_supergraph(&schema).unwrap();
     let _user_query = parse_user_query(graphql_parser::parse_query(query).unwrap());
 
     let supergraph_schema = r#"schema
@@ -568,7 +570,8 @@ type User
 "#
     .to_string();
 
-    let supergraph = parse_supergraph(&supergraph_schema).unwrap();
+    let schema = parse_graphql_schema(&supergraph_schema).unwrap();
+    let supergraph = parse_supergraph(&schema).unwrap();
     let mut user_query = parse_user_query(graphql_parser::parse_query(query).unwrap()).unwrap();
 
     let _query_plan = plan_for_user_query(&supergraph, &mut user_query).unwrap();

--- a/libs/federation_query_planner/src/supergraph.rs
+++ b/libs/federation_query_planner/src/supergraph.rs
@@ -1,9 +1,7 @@
-use std::{collections::HashMap, error::Error};
+use std::collections::HashMap;
 
-use graphql_parser::{
-  parse_schema,
-  schema::{Definition as SchemaDefinition, TypeDefinition, Value},
-};
+use conductor_common::graphql::ParsedGraphQLSchema;
+use graphql_parser::schema::{Definition as SchemaDefinition, TypeDefinition, Value};
 
 use serde::{Deserialize, Serialize};
 
@@ -36,9 +34,10 @@ fn get_argument_value(args: &[(String, Value<'_, String>)], key: &str) -> Option
     .map(|(_, v)| v.to_string().trim().to_string())
 }
 
-pub fn parse_supergraph(supergraph_schema: &str) -> Result<Supergraph, Box<dyn Error>> {
-  let result = parse_schema::<String>(supergraph_schema)?;
-
+pub fn parse_supergraph(
+  supergraph_schema: &ParsedGraphQLSchema,
+) -> Result<Supergraph, anyhow::Error> {
+  let result = supergraph_schema.clone();
   let mut parsed_supergraph = Supergraph::default();
 
   for e in result.definitions {
@@ -160,7 +159,7 @@ pub fn parse_supergraph(supergraph_schema: &str) -> Result<Supergraph, Box<dyn E
   }
 
   if parsed_supergraph.subgraphs.is_empty() || parsed_supergraph.types.is_empty() {
-    return Err("Your Supergraph Schema doesn't seem to be correct! The Parser has resulted in 0 types, and 0 subgraphs.".into());
+    return Err(anyhow::anyhow!("Your Supergraph Schema doesn't seem to be correct! The Parser has resulted in 0 types, and 0 subgraphs."));
   }
 
   Ok(parsed_supergraph)

--- a/libs/smoke_tests/src/lib.rs
+++ b/libs/smoke_tests/src/lib.rs
@@ -1,3 +1,4 @@
 mod http_get;
 mod jwt;
+mod schema_awareness;
 mod telemetry;

--- a/libs/smoke_tests/src/schema_awareness.rs
+++ b/libs/smoke_tests/src/schema_awareness.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+mod schema_awareness_smoke {
+  use conductor_common::http::ConductorHttpRequest;
+  use insta::assert_debug_snapshot;
+  use lazy_static::lazy_static;
+  use reqwest::Response;
+  use serde_json::Value;
+  use std::env::var;
+
+  lazy_static! {
+    static ref CONDUCTOR_URL: String = var("CONDUCTOR_URL").expect("CONDUCTOR_URL env var not set");
+  }
+
+  async fn make_graphql_request(req: ConductorHttpRequest) -> Response {
+    let req_builder = reqwest::Client::new()
+      .request(req.method, req.uri)
+      .headers(req.headers)
+      .body(req.body);
+
+    req_builder
+      .send()
+      .await
+      .expect("failed to run http req to conductor")
+  }
+
+  #[tokio::test]
+  async fn schema_awareness_introspection_ok() {
+    let mut req = ConductorHttpRequest::default();
+    req.method = reqwest::Method::POST;
+    req.uri = format!("{}/graphql_schema_awareness", CONDUCTOR_URL.as_str())
+      .parse()
+      .unwrap();
+    let gql_response: Response = make_graphql_request(req).await;
+
+    assert_eq!(gql_response.status(), 200);
+    let json_body = gql_response.json::<Value>().await.unwrap();
+    assert_debug_snapshot!(json_body);
+  }
+
+  #[tokio::test]
+  async fn schema_awareness_introspection_failed_validation() {
+    let mut req = ConductorHttpRequest::default();
+    req.body = serde_json::json!({
+        "query": "query { __typename invalidField }",
+    })
+    .to_string()
+    .into();
+    req.method = reqwest::Method::POST;
+    req.uri = format!("{}/graphql_schema_awareness", CONDUCTOR_URL.as_str())
+      .parse()
+      .unwrap();
+    let gql_response: Response = make_graphql_request(req).await;
+
+    assert_eq!(gql_response.status(), 200);
+    let json_body = gql_response.json::<Value>().await.unwrap();
+    assert_debug_snapshot!(json_body);
+  }
+}

--- a/libs/smoke_tests/src/snapshots/smoke_tests__schema_awareness__schema_awareness_smoke__schema_awareness_introspection_failed_validation.snap
+++ b/libs/smoke_tests/src/snapshots/smoke_tests__schema_awareness__schema_awareness_smoke__schema_awareness_introspection_failed_validation.snap
@@ -1,0 +1,17 @@
+---
+source: libs/smoke_tests/src/schema_awareness.rs
+expression: json_body
+---
+Object {
+    "errors": Array [
+        Object {
+            "locations": Array [
+                Object {
+                    "column": Number(20),
+                    "line": Number(1),
+                },
+            ],
+            "message": String("Cannot query field \"invalidField\" on type \"Query\"."),
+        },
+    ],
+}

--- a/libs/smoke_tests/src/snapshots/smoke_tests__schema_awareness__schema_awareness_smoke__schema_awareness_introspection_ok.snap
+++ b/libs/smoke_tests/src/snapshots/smoke_tests__schema_awareness__schema_awareness_smoke__schema_awareness_introspection_ok.snap
@@ -1,0 +1,9 @@
+---
+source: libs/smoke_tests/src/schema_awareness.rs
+expression: json_body
+---
+Object {
+    "data": Object {
+        "__typename": String("Query"),
+    },
+}

--- a/libs/smoke_tests/test_gw.yaml
+++ b/libs/smoke_tests/test_gw.yaml
@@ -11,6 +11,17 @@ sources:
     id: upstream
     config:
       endpoint: http://localhost:4000/
+  - type: graphql
+    id: upstream_schema_awareness
+    config:
+      endpoint: http://localhost:4000/
+      schema_awareness:
+        on_error: terminate
+        format: introspection
+        source:
+          type: remote
+          method: POST
+          url: http://localhost:4000/
 
 endpoints:
   # Just passthrough
@@ -18,6 +29,12 @@ endpoints:
     path: /graphql
     plugins:
       - type: graphiql
+
+  # Passthrough with schema awareness
+  - from: upstream_schema_awareness
+    path: /graphql_schema_awareness
+    plugins:
+      - type: graphql_validation
 
   # The following endpoint is used to test the JWT plugin
   # We are running Keycloak with some pre-baked configuration (see `docker-compose.yaml`)

--- a/plugins/disable_introspection/src/plugin.rs
+++ b/plugins/disable_introspection/src/plugin.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use crate::config::DisableIntrospectionPluginConfig;
 use conductor_common::{
   graphql::GraphQLResponse,
   http::StatusCode,
   plugin::{CreatablePlugin, Plugin, PluginError},
+  source::SourceRuntime,
   vrl_utils::{conductor_request_to_value, VrlProgramProxy},
 };
 use tracing::error;
@@ -38,7 +41,11 @@ impl CreatablePlugin for DisableIntrospectionPlugin {
 
 #[async_trait::async_trait(?Send)]
 impl Plugin for DisableIntrospectionPlugin {
-  async fn on_downstream_graphql_request(&self, ctx: &mut RequestExecutionContext) {
+  async fn on_downstream_graphql_request(
+    &self,
+    _source_runtime: Arc<Box<dyn SourceRuntime>>,
+    ctx: &mut RequestExecutionContext,
+  ) {
     if let Some(op) = &ctx.downstream_graphql_request {
       if op.is_introspection_query() {
         let should_disable = match &self.condition {

--- a/plugins/graphql_validation/Cargo.toml
+++ b/plugins/graphql_validation/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "graphql_validation_plugin"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+tracing = { workspace = true }
+serde = { workspace = true }
+async-trait = { workspace = true }
+conductor_common = { path = "../../libs/common" }
+schemars = { workspace = true }

--- a/plugins/graphql_validation/src/config.rs
+++ b/plugins/graphql_validation/src/config.rs
@@ -1,0 +1,6 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default, JsonSchema)]
+// #[schemars(example = "graphql_validation_example_1")]
+pub struct GraphQLValidationPluginConfig {}

--- a/plugins/graphql_validation/src/lib.rs
+++ b/plugins/graphql_validation/src/lib.rs
@@ -1,0 +1,5 @@
+mod config;
+mod plugin;
+
+pub use config::GraphQLValidationPluginConfig as Config;
+pub use plugin::GraphQLValidationPlugin as Plugin;

--- a/plugins/graphql_validation/src/plugin.rs
+++ b/plugins/graphql_validation/src/plugin.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use conductor_common::{
+  execute::RequestExecutionContext,
+  graphql::{validate_graphql_operation, GraphQLResponse},
+  plugin::{CreatablePlugin, Plugin, PluginError},
+  source::SourceRuntime,
+};
+
+use crate::config::GraphQLValidationPluginConfig;
+
+#[derive(Debug)]
+pub struct GraphQLValidationPlugin(GraphQLValidationPluginConfig);
+
+#[async_trait::async_trait(?Send)]
+impl CreatablePlugin for GraphQLValidationPlugin {
+  type Config = GraphQLValidationPluginConfig;
+
+  async fn create(config: Self::Config) -> Result<Box<Self>, PluginError> {
+    Ok(Box::new(Self(config)))
+  }
+}
+
+#[async_trait::async_trait(?Send)]
+impl Plugin for GraphQLValidationPlugin {
+  async fn on_downstream_graphql_request(
+    &self,
+    source_runtime: Arc<Box<dyn SourceRuntime>>,
+    request_context: &mut RequestExecutionContext,
+  ) {
+    if let Some(operation) = &request_context.downstream_graphql_request {
+      if let Some(schema) = source_runtime.schema() {
+        let errors = validate_graphql_operation(schema.as_ref(), &operation.parsed_operation);
+
+        if !errors.is_empty() {
+          let gql_response: GraphQLResponse = errors.into();
+          request_context.short_circuit(gql_response.into());
+        }
+      } else {
+        tracing::warn!(
+          "Plugin graphql_validation is enabled, but source does not have a scheme awareness available. Skipping."
+        );
+      }
+    }
+  }
+}

--- a/plugins/http_get/src/plugin.rs
+++ b/plugins/http_get/src/plugin.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use crate::config::HttpGetPluginConfig;
 
 use conductor_common::execute::RequestExecutionContext;
 use conductor_common::graphql::APPLICATION_GRAPHQL_JSON_MIME;
+use conductor_common::source::SourceRuntime;
 use conductor_common::{
   graphql::{ExtractGraphQLOperationError, GraphQLRequest, GraphQLResponse, ParsedGraphQLRequest},
   http::{
@@ -53,7 +56,11 @@ impl Plugin for HttpGetPlugin {
     }
   }
 
-  async fn on_downstream_graphql_request(&self, ctx: &mut RequestExecutionContext) {
+  async fn on_downstream_graphql_request(
+    &self,
+    _source_runtime: Arc<Box<dyn SourceRuntime>>,
+    ctx: &mut RequestExecutionContext,
+  ) {
     if ctx.downstream_http_request.method == Method::GET
       && (self.0.mutations.is_none() || self.0.mutations == Some(false))
     {

--- a/plugins/trusted_documents/src/plugin.rs
+++ b/plugins/trusted_documents/src/plugin.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
   protocols::{
     apollo_manifest::ApolloManifestPersistedDocumentsProtocol,
@@ -15,6 +17,7 @@ use conductor_common::{
   graphql::{ExtractGraphQLOperationError, GraphQLRequest, GraphQLResponse, ParsedGraphQLRequest},
   http::StatusCode,
   plugin::{CreatablePlugin, Plugin, PluginError},
+  source::SourceRuntime,
 };
 use tracing::{debug, error, info, warn};
 
@@ -161,7 +164,11 @@ impl Plugin for TrustedDocumentsPlugin {
     }
   }
 
-  async fn on_downstream_graphql_request(&self, ctx: &mut RequestExecutionContext) {
+  async fn on_downstream_graphql_request(
+    &self,
+    _source_runtime: Arc<Box<dyn SourceRuntime>>,
+    ctx: &mut RequestExecutionContext,
+  ) {
     for item in self.incoming_message_handlers.iter() {
       if let Some(response) = item.as_ref().should_prevent_execution(ctx) {
         warn!(

--- a/plugins/vrl/src/plugin.rs
+++ b/plugins/vrl/src/plugin.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use conductor_common::http::{ConductorHttpRequest, ConductorHttpResponse};
 use conductor_common::plugin::{CreatablePlugin, Plugin, PluginError};
+use conductor_common::source::SourceRuntime;
 use conductor_common::vrl_functions::vrl_fns;
 use tracing::{error, warn};
 use vrl::compiler::{Function, Program, TypeState};
@@ -81,7 +84,11 @@ impl Plugin for VrlPlugin {
     }
   }
 
-  async fn on_downstream_graphql_request(&self, ctx: &mut RequestExecutionContext) {
+  async fn on_downstream_graphql_request(
+    &self,
+    _source_runtime: Arc<Box<dyn SourceRuntime>>,
+    ctx: &mut RequestExecutionContext,
+  ) {
     if let Some(program) = &self.on_downstream_graphql_request {
       vrl_downstream_graphql_request(program, ctx);
     }

--- a/test_config/config.yaml
+++ b/test_config/config.yaml
@@ -10,13 +10,21 @@ sources:
     type: graphql
     config:
       endpoint: ${COUNTRIES_ENDPOINT:https://countries.trevorblades.com/}
+      schema_awareness:
+        polling_interval: 5m
+        source:
+          type: introspection-remote
+          url: https://countries.trevorblades.com/
 
   - id: fed
     type: federation
     config:
       expose_query_plan: true
       supergraph:
-        file: ./supergraph.graphql
+        on_error: terminate
+        source:
+          type: sdl-file
+          path: supergraph.graphql
 
 endpoints:
   - path: /other-thing
@@ -27,6 +35,8 @@ endpoints:
   - path: /graphql
     from: countries
     plugins:
+      - type: graphql_validation
+        config: {}
       - type: graphiql
       - type: telemetry
         config:

--- a/test_config/config.yaml
+++ b/test_config/config.yaml
@@ -11,9 +11,11 @@ sources:
     config:
       endpoint: ${COUNTRIES_ENDPOINT:https://countries.trevorblades.com/}
       schema_awareness:
+        format: introspection
         polling_interval: 5m
         source:
-          type: introspection-remote
+          type: remote
+          method: POST
           url: https://countries.trevorblades.com/
 
   - id: fed
@@ -21,9 +23,9 @@ sources:
     config:
       expose_query_plan: true
       supergraph:
-        on_error: terminate
+        polling_interval: "1m"
         source:
-          type: sdl-file
+          type: file
           path: supergraph.graphql
 
 endpoints:

--- a/test_config/schema.graphql
+++ b/test_config/schema.graphql
@@ -1,0 +1,84 @@
+"""
+Exposes a URL that specifies the behavior of this scalar.
+"""
+directive @specifiedBy(
+  """
+  The URL that specifies the behavior of this scalar.
+  """
+  url: String!
+) on SCALAR
+
+type Continent {
+  code: ID!
+  countries: [Country!]!
+  name: String!
+}
+
+input ContinentFilterInput {
+  code: StringQueryOperatorInput
+}
+
+type Country {
+  awsRegion: String!
+  capital: String
+  code: ID!
+  continent: Continent!
+  currencies: [String!]!
+  currency: String
+  emoji: String!
+  emojiU: String!
+  languages: [Language!]!
+  name(lang: String): String!
+  native: String!
+  phone: String!
+  phones: [String!]!
+  states: [State!]!
+  subdivisions: [Subdivision!]!
+}
+
+input CountryFilterInput {
+  code: StringQueryOperatorInput
+  continent: StringQueryOperatorInput
+  currency: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+}
+
+type Language {
+  code: ID!
+  name: String!
+  native: String!
+  rtl: Boolean!
+}
+
+input LanguageFilterInput {
+  code: StringQueryOperatorInput
+}
+
+type Query {
+  continent(code: ID!): Continent
+  continents(filter: ContinentFilterInput = {}): [Continent!]!
+  countries(filter: CountryFilterInput = {}): [Country!]!
+  country(code: ID!): Country
+  language(code: ID!): Language
+  languages(filter: LanguageFilterInput = {}): [Language!]!
+}
+
+type State {
+  code: String
+  country: Country!
+  name: String!
+}
+
+input StringQueryOperatorInput {
+  eq: String
+  in: [String!]
+  ne: String
+  nin: [String!]
+  regex: String
+}
+
+type Subdivision {
+  code: ID!
+  emoji: String
+  name: String!
+}

--- a/test_config/worker.yaml
+++ b/test_config/worker.yaml
@@ -7,11 +7,16 @@ sources:
     type: graphql
     config:
       endpoint: https://countries.trevorblades.com/
+      schema_awareness:
+        source:
+          type: introspection-remote
+          url: https://countries.trevorblades.com/
 
 endpoints:
   - path: /graphql
     from: countries
     plugins:
+      - type: graphql_validation
       - type: http_get
       - type: graphiql
       - type: telemetry

--- a/test_config/worker.yaml
+++ b/test_config/worker.yaml
@@ -8,8 +8,10 @@ sources:
     config:
       endpoint: https://countries.trevorblades.com/
       schema_awareness:
+        format: introspection
         source:
-          type: introspection-remote
+          type: remote
+          method: POST
           url: https://countries.trevorblades.com/
 
 endpoints:


### PR DESCRIPTION
Closes https://github.com/the-guild-org/conductor/issues/437
Closes https://github.com/the-guild-org/conductor/issues/436

### TODO
- [x] Generic schema awareness with the ability to process the parsed schema
- [x] Load from inline
- [x] Load from file
- [x] Load from remote (+headers, method)
- [x] Polling in background (for non-wasm)
- [x] Better logging and error handling
- [x] Fed source adjustments
- [x] also support loading from introspection
- [x] Validate incoming GraphQL operations when schema awareness is available
- [x] wasm
- [x] smoke tests
- [x] docs/website
