### PR TITLE
Update `http` to v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2",
+ "h2 0.3.24",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -419,7 +419,7 @@ dependencies = [
  "fnv",
  "futures-util",
  "handlebars",
- "http 1.0.0",
+ "http 1.1.0",
  "indexmap 2.2.1",
  "mime",
  "multer",
@@ -681,8 +681,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit 0.7.3",
  "memchr",
@@ -707,7 +707,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -748,6 +748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "basic-cookies"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +776,7 @@ dependencies = [
  "conductor_tracing",
  "criterion",
  "futures",
- "hyper",
+ "hyper 1.2.0",
  "serde",
  "serde_json",
  "tokio",
@@ -1253,14 +1259,14 @@ dependencies = [
  "futures",
  "graphql-parser",
  "graphql-tools",
- "http 0.2.12",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "lazy_static",
  "mime",
  "minitrace",
  "once_cell",
  "querystring",
- "reqwest",
+ "reqwest 0.12.0",
  "reqwest-middleware",
  "schemars",
  "serde",
@@ -1303,7 +1309,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "conductor_common",
  "conductor_config",
  "conductor_tracing",
@@ -1319,7 +1325,7 @@ dependencies = [
  "match_content_type_plugin",
  "minitrace",
  "minitrace_reqwest",
- "reqwest",
+ "reqwest 0.12.0",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -1357,7 +1363,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "rand",
- "reqwest",
+ "reqwest 0.12.0",
  "reqwest-middleware",
  "schemars",
  "serde",
@@ -1922,7 +1928,7 @@ dependencies = [
  "linked-hash-map",
  "minitrace",
  "minitrace_reqwest",
- "reqwest",
+ "reqwest 0.12.0",
  "serde",
  "serde_json",
  "tokio",
@@ -2232,6 +2238,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
+ "indexmap 2.2.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -2347,6 +2372,29 @@ checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2399,7 +2447,7 @@ dependencies = [
  "crossbeam-utils",
  "form_urlencoded",
  "futures-util",
- "hyper",
+ "hyper 0.14.28",
  "lazy_static",
  "levenshtein",
  "log",
@@ -2438,9 +2486,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.24",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2453,12 +2501,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.3",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2471,10 +2539,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2673,7 +2777,7 @@ dependencies = [
  "humantime-serde",
  "jsonwebtoken",
  "lazy_static",
- "reqwest",
+ "reqwest 0.12.0",
  "schemars",
  "serde",
  "serde_json",
@@ -2932,7 +3036,7 @@ checksum = "970001ca92870038d46118732289f041d3a81dbd1cb59d58cc3a7ea2443fe620"
 dependencies = [
  "log",
  "minitrace",
- "reqwest",
+ "reqwest 0.11.27",
  "rmp-serde",
  "serde",
 ]
@@ -2967,7 +3071,7 @@ dependencies = [
  "async-trait",
  "conductor_tracing",
  "minitrace",
- "reqwest",
+ "reqwest 0.12.0",
  "reqwest-middleware",
  "task-local-extensions",
 ]
@@ -3013,7 +3117,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "httparse",
  "log",
  "memchr",
@@ -3327,7 +3431,7 @@ dependencies = [
  "bytes",
  "http 0.2.12",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.11.27",
 ]
 
 [[package]]
@@ -3382,7 +3486,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -3996,11 +4100,53 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.24",
  "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-tls",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b48d98d932f4ee75e541614d32a7f44c889b72bd9c2e04d95edd135989df88"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.3",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-tls 0.6.0",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -4029,13 +4175,12 @@ dependencies = [
 [[package]]
 name = "reqwest-middleware"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
+source = "git+https://github.com/campeis/reqwest-middleware.git?rev=ce8ebb21c18432e61eb1687f08ac6a4523a6b5e0#ce8ebb21c18432e61eb1687f08ac6a4523a6b5e0"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 0.2.12",
- "reqwest",
+ "http 1.1.0",
+ "reqwest 0.12.0",
  "serde",
  "task-local-extensions",
  "thiserror",
@@ -4610,7 +4755,7 @@ dependencies = [
  "conductor_common",
  "insta",
  "lazy_static",
- "reqwest",
+ "reqwest 0.12.0",
  "serde",
  "serde_json",
  "serial_test",
@@ -4826,7 +4971,7 @@ dependencies = [
  "conductor_common",
  "conductor_tracing",
  "futures",
- "http 0.2.12",
+ "http 1.1.0",
  "humantime-serde",
  "minitrace",
  "minitrace-datadog",
@@ -4836,7 +4981,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-zipkin",
  "opentelemetry_sdk",
- "reqwest",
+ "reqwest 0.12.0",
  "rmp-serde",
  "schemars",
  "serde",
@@ -5099,10 +5244,10 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.24",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5702,7 +5847,7 @@ dependencies = [
 name = "wasm_polyfills"
 version = "0.0.0"
 dependencies = [
- "reqwest",
+ "reqwest 0.12.0",
  "send_wrapper",
  "tokio",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,16 @@ futures = "0.3.30"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { version = "1.0.114" }
 tracing = "0.1.40"
-http = "0.2.12"
-http-body = "0.4.6"
+http = "1.1.0"
+http-body = "1.0.0"
 bytes = "1.5.0"
 async-trait = "0.1.78"
 anyhow = "1.0.81"
-reqwest = "0.11.27"
+reqwest = "0.12"
 thiserror = "1.0.58"
-reqwest-middleware = "0.2.5"
+reqwest-middleware = { git = "https://github.com/campeis/reqwest-middleware.git", rev = "ce8ebb21c18432e61eb1687f08ac6a4523a6b5e0" }
 tracing-subscriber = "0.3.18"
-base64 = "0.21.7"
+base64 = "0.22"
 schemars = "0.8.16"
 graphql-parser = { git = "https://github.com/graphql-rust/graphql-parser.git", rev = "f75d96f1e026d0fb993944793916c1cd0597f44c" }
 vrl = { git = "https://github.com/dotansimha/vrl.git", rev = "d59b2f66727d3c345b4202b94265c580dfd0f0e9", default-features = false, features = [

--- a/libs/benches/Cargo.toml
+++ b/libs/benches/Cargo.toml
@@ -13,7 +13,7 @@ conductor_tracing = { path = "../../libs/tracing" }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-hyper = "0.14.28"
+hyper = "1.2.0"
 tokio = { workspace = true, features = ["full"] }
 actix-web = "4.5.1"
 url = "2.5.0"


### PR DESCRIPTION
currently blocked by https://github.com/open-telemetry/opentelemetry-rust/issues/1427  and waiting for https://github.com/TrueLayer/reqwest-middleware/pull/133 