### PR TITLE
chore(deps): rename minitrace to fastrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,18 +1151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
-name = "coarsetime"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a"
-dependencies = [
- "libc",
- "once_cell",
- "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,8 +1204,8 @@ dependencies = [
  "conductor_engine",
  "conductor_logger",
  "conductor_tracing",
+ "fastrace",
  "futures-util",
- "minitrace",
  "openssl",
  "tokio",
  "tracing",
@@ -1235,7 +1223,7 @@ dependencies = [
  "conductor_logger",
  "conductor_tracing",
  "console_error_panic_hook",
- "minitrace",
+ "fastrace",
  "time",
  "tracing",
  "tracing-subscriber",
@@ -1250,6 +1238,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "fastrace",
  "futures",
  "graphql-parser",
  "graphql-tools",
@@ -1257,7 +1246,6 @@ dependencies = [
  "http-body",
  "lazy_static",
  "mime",
- "minitrace",
  "once_cell",
  "querystring",
  "reqwest",
@@ -1309,6 +1297,8 @@ dependencies = [
  "conductor_tracing",
  "cors_plugin",
  "disable_introspection_plugin",
+ "fastrace",
+ "fastrace_reqwest",
  "federation_query_planner",
  "futures",
  "graphiql_plugin",
@@ -1317,8 +1307,6 @@ dependencies = [
  "humantime",
  "jwt_auth_plugin",
  "match_content_type_plugin",
- "minitrace",
- "minitrace_reqwest",
  "reqwest",
  "reqwest-middleware",
  "serde",
@@ -1353,7 +1341,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "conductor_common",
- "minitrace",
+ "fastrace",
  "opentelemetry",
  "opentelemetry_sdk",
  "rand",
@@ -1782,13 +1770,13 @@ dependencies = [
  "conductor_tracing",
  "cors_plugin",
  "disable_introspection_plugin",
+ "fastrace",
  "graphiql_plugin",
  "http_get_plugin",
  "httpmock",
  "jwt_auth_plugin",
  "lazy_static",
  "match_content_type_plugin",
- "minitrace",
  "serde",
  "serde_json",
  "telemetry_plugin",
@@ -1891,6 +1879,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrace"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfd798348670042f0628810b10bc11b767c1f42aafbd3b1ae31f282740c549fe"
+dependencies = [
+ "fastrace-macro",
+ "minstant",
+ "once_cell",
+ "parking_lot",
+ "pin-project",
+ "rand",
+ "rtrb",
+]
+
+[[package]]
+name = "fastrace-datadog"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac7dd29d59659e8572dfd6df7abae918d26165dd70029e06c902b3c72754ec3a"
+dependencies = [
+ "fastrace",
+ "log",
+ "reqwest",
+ "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "fastrace-jaeger"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e43a14e587f06907b1a82bb2b510cc9db9f7f2f92c5f108d397ee425f4a88d1"
+dependencies = [
+ "fastrace",
+ "log",
+ "thrift_codec",
+]
+
+[[package]]
+name = "fastrace-macro"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea27de901dc6b14aa952aeefcc41144da4dc97e4db3eb3593c19f3b80406786"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "fastrace_reqwest"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "conductor_tracing",
+ "fastrace",
+ "reqwest",
+ "reqwest-middleware",
+ "task-local-extensions",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,13 +1966,13 @@ dependencies = [
  "conductor_common",
  "conductor_tracing",
  "criterion",
+ "fastrace",
+ "fastrace_reqwest",
  "futures",
  "graphql-parser",
  "insta",
  "lazy_static",
  "linked-hash-map",
- "minitrace",
- "minitrace_reqwest",
  "reqwest",
  "serde",
  "serde_json",
@@ -2908,70 +2959,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minitrace"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2df1d765f7ec35138abeefde2a023c3b26b8d9bb2e4a3b98ed132acf2d755a7"
-dependencies = [
- "futures",
- "minitrace-macro",
- "minstant",
- "once_cell",
- "parking_lot",
- "pin-project",
- "rand",
- "rtrb",
-]
-
-[[package]]
-name = "minitrace-datadog"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970001ca92870038d46118732289f041d3a81dbd1cb59d58cc3a7ea2443fe620"
-dependencies = [
- "log",
- "minitrace",
- "reqwest",
- "rmp-serde",
- "serde",
-]
-
-[[package]]
-name = "minitrace-jaeger"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b4d7da9760b1c17119341a59efca097ea8f9bc943a369598162f2ef25c4e74"
-dependencies = [
- "log",
- "minitrace",
- "thrift_codec",
-]
-
-[[package]]
-name = "minitrace-macro"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36aca96c5da5b6a8c7f75910fb52c8d5aecb70f27d821adeae06ba54d2cf74b0"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "minitrace_reqwest"
-version = "0.0.0"
-dependencies = [
- "async-trait",
- "conductor_tracing",
- "minitrace",
- "reqwest",
- "reqwest-middleware",
- "task-local-extensions",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,11 +2969,10 @@ dependencies = [
 
 [[package]]
 name = "minstant"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e326a3745e3f61d1715722ed4e72c0e9689aac76f1496c4deeeb64dd68f93fb"
+checksum = "1fb9b5c752f145ac5046bccc3c4f62892e3c950c1d1eab80c5949cd68a2078db"
 dependencies = [
- "coarsetime",
  "ctor 0.1.26",
  "web-time",
 ]
@@ -4824,12 +4810,12 @@ dependencies = [
  "async-trait",
  "conductor_common",
  "conductor_tracing",
+ "fastrace",
+ "fastrace-datadog",
+ "fastrace-jaeger",
  "futures",
  "http 0.2.12",
  "humantime-serde",
- "minitrace",
- "minitrace-datadog",
- "minitrace-jaeger",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -4910,9 +4896,9 @@ dependencies = [
 
 [[package]]
 name = "thrift_codec"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce3200b189fd4733eb2bb22235755c8aa0361ba1c66b67db54893144d147279"
+checksum = "83d957f535b242b91aa9f47bde08080f9a6fef276477e55b0079979d002759d5"
 dependencies = [
  "byteorder",
  "trackable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ vrl = { git = "https://github.com/dotansimha/vrl.git", rev = "d59b2f66727d3c345b
   "value",
   "stdlib",
 ] }
-minitrace = "0.6.4"
+fastrace = "0.6.8"
 
 [profile.release.package.conductor-cf-worker]
 strip = true

--- a/bin/cloudflare_worker/Cargo.toml
+++ b/bin/cloudflare_worker/Cargo.toml
@@ -24,4 +24,4 @@ tracing-web = "0.1.3"
 tracing-subscriber = { workspace = true, features = ['time', 'json'] }
 time = { version = "0.3.36", features = ['wasm-bindgen'] }
 console_error_panic_hook = "0.1.7"
-minitrace = { workspace = true, features = ["enable"] }
+fastrace = { workspace = true, features = ["enable"] }

--- a/bin/cloudflare_worker/src/http_tracing.rs
+++ b/bin/cloudflare_worker/src/http_tracing.rs
@@ -1,6 +1,6 @@
 use conductor_common::http::{header::*, StatusCode};
 use conductor_tracing::{otel_attrs::*, trace_id::generate_trace_id};
-use minitrace::{
+use fastrace::{
   collector::{SpanContext, SpanId},
   Span,
 };

--- a/bin/conductor/Cargo.toml
+++ b/bin/conductor/Cargo.toml
@@ -30,4 +30,4 @@ tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "time",
 ] }
-minitrace = { workspace = true, features = ["enable"] }
+fastrace = { workspace = true, features = ["enable"] }

--- a/bin/conductor/src/fastrace_actix.rs
+++ b/bin/conductor/src/fastrace_actix.rs
@@ -5,26 +5,26 @@ use actix_web::{
 };
 use conductor_engine::gateway::ConductorGatewayRouteData;
 use conductor_tracing::{otel_attrs::*, trace_id::generate_trace_id};
-use futures_util::future::LocalBoxFuture;
-use minitrace::{
+use fastrace::{
   collector::{SpanContext, SpanId},
   Span,
 };
+use futures_util::future::LocalBoxFuture;
 use std::{
   future::{ready, Ready},
   sync::Arc,
 };
 use ulid::Ulid;
 
-pub struct MinitraceTransform;
+pub struct FastraceTransform;
 
-impl MinitraceTransform {
+impl FastraceTransform {
   pub fn new() -> Self {
-    MinitraceTransform
+    FastraceTransform
   }
 }
 
-impl<S, B> Transform<S, ServiceRequest> for MinitraceTransform
+impl<S, B> Transform<S, ServiceRequest> for FastraceTransform
 where
   S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
   S::Future: 'static,
@@ -33,11 +33,11 @@ where
   type Response = ServiceResponse<B>;
   type Error = Error;
   type InitError = ();
-  type Transform = MinitraceMiddleware<S>;
+  type Transform = FastraceMiddleware<S>;
   type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
   fn new_transform(&self, service: S) -> Self::Future {
-    ready(Ok(MinitraceMiddleware { service }))
+    ready(Ok(FastraceMiddleware { service }))
   }
 }
 
@@ -189,11 +189,11 @@ fn build_response_properties<B>(
   properties
 }
 
-pub struct MinitraceMiddleware<S> {
+pub struct FastraceMiddleware<S> {
   service: S,
 }
 
-impl<S, B> Service<ServiceRequest> for MinitraceMiddleware<S>
+impl<S, B> Service<ServiceRequest> for FastraceMiddleware<S>
 where
   S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
   S::Future: 'static,

--- a/libs/benches/bench.rs
+++ b/libs/benches/bench.rs
@@ -5,7 +5,7 @@ use conductor_config::{
   ConductorConfig, EndpointDefinition, GraphQLSourceConfig, SourceDefinition,
 };
 use conductor_engine::gateway::ConductorGateway;
-use conductor_tracing::minitrace_mgr::MinitraceManager;
+use conductor_tracing::fastrace_mgr::FastraceManager;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use futures::future::join_all;
 use hyper::Client;
@@ -94,7 +94,7 @@ fn criterion_benchmark(c: &mut Criterion) {
       plugins: None,
     };
 
-    let mut tracing_mgr = MinitraceManager::default();
+    let mut tracing_mgr = FastraceManager::default();
     let gw_future = ConductorGateway::new(&config, &mut tracing_mgr);
     let rt = Runtime::new().unwrap();
     let gw = rt.block_on(gw_future).unwrap();

--- a/libs/common/Cargo.toml
+++ b/libs/common/Cargo.toml
@@ -30,5 +30,5 @@ mime = "0.3.17"
 url = "2.5.0"
 querystring = "1.1.0"
 once_cell = "1.19.0"
-minitrace = { workspace = true }
+fastrace = { workspace = true }
 lazy_static = "1.4.0"

--- a/libs/common/src/graphql.rs
+++ b/libs/common/src/graphql.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use bytes::Bytes;
+use fastrace::{trace, Span};
 use graphql_parser::{
   parse_query, parse_schema,
   query::{Definition, Document, OperationDefinition, ParseError},
@@ -14,7 +15,6 @@ use graphql_tools::validation::{
 };
 use lazy_static::lazy_static;
 use mime::{Mime, APPLICATION_JSON};
-use minitrace::{trace, Span};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::{Error as SerdeError, Map, Value};

--- a/libs/e2e_tests/Cargo.toml
+++ b/libs/e2e_tests/Cargo.toml
@@ -27,4 +27,4 @@ telemetry_plugin = { path = "../../plugins/telemetry", features = [
 match_content_type_plugin = { path = "../../plugins/match_content_type" }
 vrl_plugin = { path = "../../plugins/vrl" }
 jwt_auth_plugin = { path = "../../plugins/jwt_auth" }
-minitrace = { workspace = true, features = ["enable"] }
+fastrace = { workspace = true, features = ["enable"] }

--- a/libs/e2e_tests/tests/plugin_telemetry.rs
+++ b/libs/e2e_tests/tests/plugin_telemetry.rs
@@ -3,10 +3,10 @@ pub mod telemetry {
   use conductor_tracing::reporters::TracingReporter;
   use conductor_tracing::routed_reporter::test_utils::TestReporter;
   use conductor_tracing::{
-    minitrace_mgr::MinitraceManager, otel_attrs::*, trace_id::generate_trace_id,
+    fastrace_mgr::FastraceManager, otel_attrs::*, trace_id::generate_trace_id,
   };
   use e2e::suite::TestSuite;
-  use minitrace::{
+  use fastrace::{
     collector::{Config, SpanContext, SpanId},
     future::FutureExt,
     Span,
@@ -23,13 +23,13 @@ pub mod telemetry {
     .await
     .unwrap();
 
-    let mut minitrace_mgr = MinitraceManager::default();
+    let mut fastrace_mgr = FastraceManager::default();
     plugin.configure_tracing_for_test(
       0,
       TracingReporter::Simple(Box::new(reporter)),
-      &mut minitrace_mgr,
+      &mut fastrace_mgr,
     );
-    minitrace::set_reporter(minitrace_mgr.build_root_reporter(), Config::default());
+    fastrace::set_reporter(fastrace_mgr.build_root_reporter(), Config::default());
 
     let test = TestSuite {
       plugins: vec![plugin],
@@ -43,7 +43,7 @@ pub mod telemetry {
       .in_span(root_span)
       .await;
 
-    minitrace::flush();
+    fastrace::flush();
 
     let spans = spans.lock().unwrap();
 

--- a/libs/engine/Cargo.toml
+++ b/libs/engine/Cargo.toml
@@ -38,8 +38,8 @@ jwt_auth_plugin = { path = "../../plugins/jwt_auth" }
 federation_query_planner = { path = "../../libs/federation_query_planner" }
 telemetry_plugin = { path = "../../plugins/telemetry" }
 graphql_validation_plugin = { path = "../../plugins/graphql_validation" }
-minitrace = { workspace = true }
-minitrace_reqwest = { path = "../minitrace_reqwest" }
+fastrace = { workspace = true }
+fastrace_reqwest = { path = "../fastrace_reqwest" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }

--- a/libs/engine/src/gateway.rs
+++ b/libs/engine/src/gateway.rs
@@ -10,11 +10,11 @@ use conductor_common::{
 };
 use conductor_config::{ConductorConfig, EndpointDefinition, SourceDefinition};
 use conductor_tracing::{
-  minitrace_mgr::MinitraceManager,
+  fastrace_mgr::FastraceManager,
   otel_attrs::CONDUCTOR_SOURCE,
   otel_utils::{create_graphql_error_span_properties, create_graphql_span},
 };
-use minitrace::{future::FutureExt, trace, Span};
+use fastrace::{future::FutureExt, trace, Span};
 use reqwest::{Method, StatusCode};
 use tracing::error;
 
@@ -96,7 +96,7 @@ impl ConductorGateway {
     config_object: &ConductorConfig,
     endpoint_config: &EndpointDefinition,
     source_runtime: Arc<Box<dyn SourceRuntime>>,
-    tracing_manager: &mut MinitraceManager,
+    tracing_manager: &mut FastraceManager,
   ) -> Result<ConductorGatewayRouteData, GatewayError> {
     let global_plugins = &config_object.plugins;
     let combined_plugins = global_plugins
@@ -123,7 +123,7 @@ impl ConductorGateway {
 
   pub async fn new(
     config_object: &ConductorConfig,
-    tracing_manager: &mut MinitraceManager,
+    tracing_manager: &mut FastraceManager,
   ) -> Result<Self, GatewayError> {
     let mut route_mapping: Vec<ConductorGatewayRoute> = vec![];
     let mut sources: HashMap<String, Arc<Box<dyn SourceRuntime>>> = HashMap::new();

--- a/libs/engine/src/plugin_manager.rs
+++ b/libs/engine/src/plugin_manager.rs
@@ -9,7 +9,7 @@ use conductor_common::{
   source::SourceRuntime,
 };
 use conductor_config::PluginDefinition;
-use conductor_tracing::minitrace_mgr::MinitraceManager;
+use conductor_tracing::fastrace_mgr::FastraceManager;
 use reqwest::Response;
 
 #[derive(Debug, Default)]
@@ -35,7 +35,7 @@ impl PluginManagerImpl {
 
   pub async fn new(
     plugins_config: &Option<Vec<PluginDefinition>>,
-    tracing_manager: &mut MinitraceManager,
+    tracing_manager: &mut FastraceManager,
     tenant_id: u32,
   ) -> Result<Self, PluginError> {
     let mut instance = PluginManagerImpl::default();

--- a/libs/engine/src/source/federation_source.rs
+++ b/libs/engine/src/source/federation_source.rs
@@ -4,11 +4,11 @@ use conductor_common::graphql::GraphQLResponse;
 use conductor_common::plugin_manager::PluginManager;
 use conductor_common::source::{GraphQLSourceInitError, SourceError, SourceRuntime};
 use conductor_config::{FederationSourceConfig, SchemaAwarenessConfig};
+use fastrace_reqwest::{traced_reqwest, TracedHttpClient};
 use federation_query_planner::supergraph::parse_supergraph;
 use federation_query_planner::supergraph::Supergraph;
 use federation_query_planner::FederationExecutor;
 use futures::lock::Mutex;
-use minitrace_reqwest::{traced_reqwest, TracedHttpClient};
 use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 

--- a/libs/engine/src/source/graphql_source.rs
+++ b/libs/engine/src/source/graphql_source.rs
@@ -7,7 +7,7 @@ use conductor_common::{
   plugin_manager::PluginManager,
 };
 use conductor_config::GraphQLSourceConfig;
-use minitrace_reqwest::{traced_reqwest, TracedHttpClient};
+use fastrace_reqwest::{traced_reqwest, TracedHttpClient};
 use reqwest::{header::HeaderValue, Method, StatusCode};
 use tracing::debug;
 

--- a/libs/fastrace_reqwest/Cargo.toml
+++ b/libs/fastrace_reqwest/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "minitrace_reqwest"
+name = "fastrace_reqwest"
 version = "0.0.0"
 edition = "2021"
 
@@ -7,7 +7,7 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-minitrace = { workspace = true }
+fastrace = { workspace = true }
 reqwest-middleware = { workspace = true }
 conductor_tracing = { path = "../tracing" }
 reqwest = { workspace = true }

--- a/libs/fastrace_reqwest/src/lib.rs
+++ b/libs/fastrace_reqwest/src/lib.rs
@@ -1,5 +1,5 @@
 use conductor_tracing::otel_attrs::*;
-use minitrace::Span;
+use fastrace::Span;
 use reqwest::{Request, Response, StatusCode};
 use reqwest_middleware::ClientBuilder;
 use reqwest_middleware::ClientWithMiddleware;
@@ -7,7 +7,7 @@ use reqwest_middleware::{Error, Middleware, Next, Result};
 use task_local_extensions::Extensions;
 
 #[derive(Debug)]
-pub struct MinitraceReqwestMiddleware;
+pub struct FastraceReqwestMiddleware;
 
 #[inline]
 fn get_span_status(request_status: StatusCode) -> Option<&'static str> {
@@ -26,7 +26,7 @@ fn get_span_status(request_status: StatusCode) -> Option<&'static str> {
   }
 }
 
-impl MinitraceReqwestMiddleware {
+impl FastraceReqwestMiddleware {
   #[inline]
   pub fn response_properties(
     &self,
@@ -93,7 +93,7 @@ impl MinitraceReqwestMiddleware {
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl Middleware for MinitraceReqwestMiddleware {
+impl Middleware for FastraceReqwestMiddleware {
   async fn handle(
     &self,
     req: Request,
@@ -113,7 +113,7 @@ impl Middleware for MinitraceReqwestMiddleware {
 
 pub fn traced_reqwest(raw_client: reqwest::Client) -> TracedHttpClient {
   ClientBuilder::new(raw_client)
-    .with(MinitraceReqwestMiddleware)
+    .with(FastraceReqwestMiddleware)
     .build()
 }
 

--- a/libs/federation_query_planner/Cargo.toml
+++ b/libs/federation_query_planner/Cargo.toml
@@ -21,8 +21,8 @@ futures = { workspace = true }
 lazy_static = "1.4.0"
 tracing = { workspace = true }
 async-graphql = { version = "7.0.1", features = ["dynamic-schema"] }
-minitrace = { workspace = true }
-minitrace_reqwest = { path = "../minitrace_reqwest" }
+fastrace = { workspace = true }
+fastrace_reqwest = { path = "../fastrace_reqwest" }
 
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["yaml", "json"] }

--- a/libs/federation_query_planner/src/lib.rs
+++ b/libs/federation_query_planner/src/lib.rs
@@ -7,10 +7,10 @@ use constants::CONDUCTOR_INTERNAL_SERVICE_RESOLVER;
 use executor::{
   dynamically_build_schema_from_supergraph, find_objects_matching_criteria, QueryResponse,
 };
+use fastrace::Span;
 use futures::future::join_all;
 use futures::lock::Mutex;
 use graphql_parser::query::Document;
-use minitrace::Span;
 use query_planner::QueryStep;
 use query_planner::{Parallel, QueryPlan};
 use reqwest::header::{HeaderValue, CONTENT_TYPE};
@@ -30,7 +30,7 @@ pub mod type_merge;
 pub mod user_query;
 
 pub struct FederationExecutor<'a> {
-  pub client: &'a minitrace_reqwest::TracedHttpClient,
+  pub client: &'a fastrace_reqwest::TracedHttpClient,
   pub plugin_manager: Arc<Box<dyn PluginManager>>,
   pub supergraph: &'a Supergraph,
 }

--- a/libs/tracing/Cargo.toml
+++ b/libs/tracing/Cargo.toml
@@ -23,5 +23,5 @@ opentelemetry_sdk = { version = "0.22.1", features = ["trace"] }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 task-local-extensions = "0.1.4"
-minitrace = { workspace = true }
+fastrace = { workspace = true }
 rand = "0.8.5"

--- a/libs/tracing/src/fastrace_mgr.rs
+++ b/libs/tracing/src/fastrace_mgr.rs
@@ -1,4 +1,4 @@
-use minitrace::collector::Reporter;
+use fastrace::collector::Reporter;
 
 use crate::{
   reporters::TracingReporter, routed_reporter::RoutedReporter, trace_id::extract_tenant_id,
@@ -9,17 +9,17 @@ use std::{
 };
 
 #[derive(Default)]
-pub struct MinitraceManager {
+pub struct FastraceManager {
   reporters: HashMap<u32, Arc<Mutex<TracingReporter>>>,
 }
 
-impl std::fmt::Debug for MinitraceManager {
+impl std::fmt::Debug for FastraceManager {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("MinitraceManager").finish()
+    f.debug_struct("FastraceManager").finish()
   }
 }
 
-impl MinitraceManager {
+impl FastraceManager {
   pub fn add_reporter(&mut self, tenant_id: u32, reporter: TracingReporter) {
     self
       .reporters
@@ -39,7 +39,7 @@ impl MinitraceManager {
   #[allow(clippy::await_holding_lock)]
   pub async fn shutdown(self) {
     tracing::info!("Shutting down tracing reporters...");
-    minitrace::flush();
+    fastrace::flush();
 
     for (_, reporter) in self.reporters {
       let mut reporter = reporter

--- a/libs/tracing/src/lib.rs
+++ b/libs/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod minitrace_mgr;
+pub mod fastrace_mgr;
 pub mod otel_attrs;
 pub mod otel_utils;
 pub mod reporters;

--- a/libs/tracing/src/otel_utils.rs
+++ b/libs/tracing/src/otel_utils.rs
@@ -2,7 +2,7 @@ use conductor_common::graphql::GraphQLError;
 use conductor_common::graphql::ParsedGraphQLRequest;
 use conductor_common::Definition;
 use conductor_common::OperationDefinition;
-use minitrace::Span;
+use fastrace::Span;
 
 use crate::otel_attrs::*;
 

--- a/libs/tracing/src/reporters.rs
+++ b/libs/tracing/src/reporters.rs
@@ -1,4 +1,4 @@
-use minitrace::collector::{Reporter as MinitraceSyncReporter, SpanRecord};
+use fastrace::collector::{Reporter as FastraceSyncReporter, SpanRecord};
 
 #[async_trait::async_trait(?Send)]
 pub trait AsyncReporter: Send + 'static {
@@ -23,15 +23,15 @@ impl AggregatingReporter {
   }
 }
 
-impl MinitraceSyncReporter for AggregatingReporter {
+impl FastraceSyncReporter for AggregatingReporter {
   fn report(&mut self, spans: &[SpanRecord]) {
     self.collected_spans.extend_from_slice(spans);
   }
 }
 
 pub enum TracingReporter {
-  // A simple wrapper around a generic Reporter created from minitrace package.
-  Simple(Box<dyn MinitraceSyncReporter>),
+  // A simple wrapper around a generic Reporter created from fastrace package.
+  Simple(Box<dyn FastraceSyncReporter>),
   // A special reporter that aggregates the spans in memory, and can later ship the spans on demand.
   // This is a workaround that collects traces in-memory, and later ships them asynchronously, on a WASM runtime.
   Aggregating(AggregatingReporter),

--- a/libs/tracing/src/routed_reporter.rs
+++ b/libs/tracing/src/routed_reporter.rs
@@ -3,7 +3,7 @@ use std::{
   sync::{Arc, Mutex},
 };
 
-use minitrace::collector::{Reporter, SpanRecord};
+use fastrace::collector::{Reporter, SpanRecord};
 
 use crate::reporters::TracingReporter;
 
@@ -68,7 +68,7 @@ impl Reporter for RoutedReporter {
 pub mod test_utils {
   use std::sync::{Arc, Mutex};
 
-  use minitrace::collector::{Reporter, SpanRecord};
+  use fastrace::collector::{Reporter, SpanRecord};
 
   pub struct TestReporter {
     captured_spans: Arc<Mutex<Vec<SpanRecord>>>,
@@ -105,7 +105,7 @@ pub mod test_utils {
 //     let (spans0, reporter0) = test_utils::TestReporter::new();
 //     let (spans1, reporter1) = test_utils::TestReporter::new();
 //     let mut routed_reporter =
-//       RoutedReporter::new(|span| Some(MinitraceManager::extract_tenant_id(span.trace_id)))
+//       RoutedReporter::new(|span| Some(FastraceManager::extract_tenant_id(span.trace_id)))
 //         .with_reporter(0, Box::new(reporter0).into())
 //         .with_reporter(1, Box::new(reporter1).into());
 
@@ -113,27 +113,27 @@ pub mod test_utils {
 //       .report(&vec![
 //         // This one goes to tenant 2, it does not exists
 //         SpanRecord {
-//           trace_id: MinitraceManager::generate_trace_id(2),
+//           trace_id: FastraceManager::generate_trace_id(2),
 //           ..Default::default()
 //         },
 //         // This one goes to tenant 0
 //         SpanRecord {
-//           trace_id: MinitraceManager::generate_trace_id(0),
+//           trace_id: FastraceManager::generate_trace_id(0),
 //           ..Default::default()
 //         },
 //         // This one goes to tenant 0
 //         SpanRecord {
-//           trace_id: MinitraceManager::generate_trace_id(0),
+//           trace_id: FastraceManager::generate_trace_id(0),
 //           ..Default::default()
 //         },
 //         // This one goes to tenant 1
 //         SpanRecord {
-//           trace_id: MinitraceManager::generate_trace_id(1),
+//           trace_id: FastraceManager::generate_trace_id(1),
 //           ..Default::default()
 //         },
 //         // This one goes to tenant 2, it does not exists
 //         SpanRecord {
-//           trace_id: MinitraceManager::generate_trace_id(2),
+//           trace_id: FastraceManager::generate_trace_id(2),
 //           ..Default::default()
 //         },
 //       ])
@@ -143,17 +143,17 @@ pub mod test_utils {
 //       .report(&vec![
 //         // This one goes to tenant 1
 //         SpanRecord {
-//           trace_id: MinitraceManager::generate_trace_id(1),
+//           trace_id: FastraceManager::generate_trace_id(1),
 //           ..Default::default()
 //         },
 //         // This one goes to tenant 1
 //         SpanRecord {
-//           trace_id: MinitraceManager::generate_trace_id(1),
+//           trace_id: FastraceManager::generate_trace_id(1),
 //           ..Default::default()
 //         },
 //         // This one goes to tenant 2
 //         SpanRecord {
-//           trace_id: MinitraceManager::generate_trace_id(2),
+//           trace_id: FastraceManager::generate_trace_id(2),
 //           ..Default::default()
 //         },
 //       ])

--- a/libs/tracing/src/trace_id.rs
+++ b/libs/tracing/src/trace_id.rs
@@ -1,4 +1,4 @@
-use minitrace::collector::TraceId;
+use fastrace::collector::TraceId;
 
 pub fn generate_trace_id(tenant_id: u32) -> TraceId {
   let uniq: u32 = rand::random();

--- a/plugins/telemetry/Cargo.toml
+++ b/plugins/telemetry/Cargo.toml
@@ -21,7 +21,7 @@ schemars = { workspace = true }
 humantime-serde = "1.1.1"
 opentelemetry = { version = "0.22.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.22.1", features = ["trace"] }
-minitrace = { workspace = true }
+fastrace = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm_polyfills = { path = "../../libs/wasm_polyfills" }
@@ -39,11 +39,11 @@ opentelemetry-otlp = { version = "0.15.0", features = [
   "grpc-tonic",
   "http-proto",
 ] }
-minitrace-datadog = "0.6.4"
+fastrace-datadog = "0.6.8"
 opentelemetry-zipkin = { version = "0.20.0", default-features = false, features = [
   "reqwest-client",
 ] }
-minitrace-jaeger = "0.6.4"
+fastrace-jaeger = "0.6.8"
 opentelemetry-http = { version = "0.11.1", default-features = false, features = [
   "reqwest",
 ] }

--- a/plugins/telemetry/src/reporter/open_telemetry.rs
+++ b/plugins/telemetry/src/reporter/open_telemetry.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::time::Duration;
 use std::time::UNIX_EPOCH;
 
-use minitrace::collector::EventRecord;
-use minitrace::collector::Reporter;
-use minitrace::prelude::*;
+use fastrace::collector::EventRecord;
+use fastrace::collector::Reporter;
+use fastrace::prelude::*;
 use opentelemetry::trace::Event;
 use opentelemetry::trace::SpanContext;
 use opentelemetry::trace::SpanKind;
@@ -22,7 +22,7 @@ use opentelemetry_sdk::trace::SpanEvents;
 use opentelemetry_sdk::trace::SpanLinks;
 use opentelemetry_sdk::Resource;
 
-/// [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-rust) reporter for `minitrace`.
+/// [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-rust) reporter for `fastrace`.
 ///
 /// `OpenTelemetryReporter` exports trace records to remote agents that OpenTelemetry
 /// supports, which includes Jaeger, Datadog, Zipkin, and OpenTelemetry Collector.

--- a/plugins/telemetry/src/wasm_reporter/console_reporter.rs
+++ b/plugins/telemetry/src/wasm_reporter/console_reporter.rs
@@ -1,4 +1,4 @@
-use minitrace::collector::{Reporter, SpanRecord};
+use fastrace::collector::{Reporter, SpanRecord};
 
 pub struct WasmConsoleReporter;
 

--- a/plugins/telemetry/src/wasm_reporter/datadog_reporter.rs
+++ b/plugins/telemetry/src/wasm_reporter/datadog_reporter.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, net::SocketAddr};
 
 use conductor_tracing::reporters::AsyncReporter;
-use minitrace::collector::SpanRecord;
+use fastrace::collector::SpanRecord;
 use rmp_serde::Serializer;
 use serde::Serialize;
 

--- a/plugins/telemetry/src/wasm_reporter/otlp_reporter.rs
+++ b/plugins/telemetry/src/wasm_reporter/otlp_reporter.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 
 use conductor_common::http::Bytes;
 use conductor_tracing::reporters::AsyncReporter;
+use fastrace::collector::{EventRecord, SpanRecord};
 use http::{Request, Response};
-use minitrace::collector::{EventRecord, SpanRecord};
 use opentelemetry::{
   trace::{Event, SpanContext, SpanKind, Status, TraceFlags, TraceState},
   InstrumentationLibrary, Key, KeyValue, StringValue, Value,

--- a/renovate.json
+++ b/renovate.json
@@ -11,12 +11,12 @@
       "matchPackageNames": ["async-graphql", "async-graphql-actix-web"]
     },
     {
-      "groupName": "minitrace",
+      "groupName": "fastrace",
       "matchPackageNames": [
-        "minitrace-datadog",
-        "minitrace-jaeger",
-        "minitrace-opentelemetry",
-        "minitrace"
+        "fastrace-datadog",
+        "fastrace-jaeger",
+        "fastrace-opentelemetry",
+        "fastrace"
       ]
     },
     {


### PR DESCRIPTION
Hi, I'm a maintainer of `minitrace`, which has been renamed the project to `fastrace` recently. You may see the details if interested https://github.com/tikv/minitrace-rust/issues/229. Feel free to ask me if you have any concern :D